### PR TITLE
Fix custom input state memory growth

### DIFF
--- a/ui/text_editor.v
+++ b/ui/text_editor.v
@@ -1,5 +1,7 @@
 module ui2
 
+import strings
+
 // TextSelection stores positions as rune offsets, so cursor movement is stable
 // for UTF-8 text. The selection is collapsed when anchor == caret.
 pub struct TextSelection {
@@ -130,14 +132,29 @@ fn (mut e TextEditor) clamp_selection() {
 }
 
 pub fn rune_len(text string) int {
-	return text.runes().len
+	mut count := 0
+	for _ in text {
+		count++
+	}
+	return count
 }
 
+@[manualfree]
 fn replace_rune_range(text string, start int, end int, value string) string {
-	runes := text.runes()
+	mut runes := text.runes()
+	defer {
+		unsafe { runes.free() }
+	}
 	from := clamp_int(start, 0, runes.len)
 	to := clamp_int(end, from, runes.len)
-	return runes[..from].string() + value + runes[to..].string()
+	mut result := strings.new_builder(text.len + value.len)
+	defer {
+		unsafe { result.free() }
+	}
+	result.write_runes(runes[..from])
+	result.write_string(value)
+	result.write_runes(runes[to..])
+	return result.str()
 }
 
 fn clamp_int(value int, min int, max int) int {

--- a/ui/text_editor.v
+++ b/ui/text_editor.v
@@ -132,11 +132,7 @@ fn (mut e TextEditor) clamp_selection() {
 }
 
 pub fn rune_len(text string) int {
-	mut count := 0
-	for _ in text {
-		count++
-	}
-	return count
+	return text.runes().len
 }
 
 @[manualfree]

--- a/ui/text_editor_test.v
+++ b/ui/text_editor_test.v
@@ -19,6 +19,10 @@ fn test_text_editor_deletes_utf8_by_rune() {
 	assert editor.text == 'a'
 }
 
+fn test_rune_len_counts_utf8_code_points() {
+	assert rune_len('a🙂é') == 3
+}
+
 fn test_text_editor_clamps_publicly_mutated_selection_before_editing() {
 	mut editor := text_editor('a')
 	editor.selection.anchor = 100

--- a/ui/ui_custom_test.v
+++ b/ui/ui_custom_test.v
@@ -34,6 +34,26 @@ $if ui2_custom_rendering ? {
 		quit()
 	}
 
+	fn test_custom_text_editor_replaces_owned_state_after_caret_moves() {
+		g_text_values = map[string]string{}
+		g_text_props = map[string]string{}
+		g_text_editors = map[string]TextEditor{}
+		g_text_kinds = map[string]Kind{}
+		g_active_fields = map[string]bool{
+			'field': true
+		}
+		g_focused_field = 'field'
+		replace_text_value('field', 'abc')
+		replace_text_editor('field', text_editor('abc'.clone()))
+		handle_key_down(.left)
+		handle_key_down(.backspace)
+		handle_char_input(`x`)
+		assert text('field') == 'axc'
+		forget_text_state('field')
+		g_active_fields = map[string]bool{}
+		g_focused_field = ''
+	}
+
 	fn test_custom_pointer_event_ids_are_normalized() {
 		assert pointer_event_id('down', 'surface', 20, 30) == 'pointer:down:surface:20.0:30.0'
 		assert pointer_event_id('drag', 'surface', 40, 50) == 'pointer:drag:surface:40.0:50.0'

--- a/ui/ui_immediate.c.v
+++ b/ui/ui_immediate.c.v
@@ -135,6 +135,63 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 	__global g_dropdown_hover = -1
 	__global g_dropdown_scroll = 0.0
 
+	// Map values are copied byte-for-byte when an existing key is replaced.
+	// Unlike keys, their nested strings are not released by map.set. The text
+	// state below changes on every keystroke, so it owns clones explicitly and
+	// disposes the previous value before overwriting it.
+	@[manualfree]
+	fn free_owned_string(value string) {
+		unsafe { value.free() }
+	}
+
+	@[manualfree]
+	fn replace_text_value(id string, value string) {
+		owned := value.clone()
+		if previous := g_text_values[id] {
+			free_owned_string(previous)
+		}
+		g_text_values[id] = owned
+	}
+
+	@[manualfree]
+	fn replace_text_prop(id string, value string) {
+		owned := value.clone()
+		if previous := g_text_props[id] {
+			free_owned_string(previous)
+		}
+		g_text_props[id] = owned
+	}
+
+	@[manualfree]
+	fn replace_text_editor(id string, editor TextEditor) {
+		if previous := g_text_editors[id] {
+			// Caret-only updates retain the editor's text allocation. Releasing
+			// it in that case would leave the replacement editor pointing at
+			// freed memory.
+			if previous.text.str != editor.text.str {
+				free_owned_string(previous.text)
+			}
+		}
+		g_text_editors[id] = editor
+	}
+
+	@[manualfree]
+	fn forget_text_state(id string) {
+		if value := g_text_values[id] {
+			free_owned_string(value)
+		}
+		if prop := g_text_props[id] {
+			free_owned_string(prop)
+		}
+		if editor := g_text_editors[id] {
+			free_owned_string(editor.text)
+		}
+		g_text_values.delete(id)
+		g_text_props.delete(id)
+		g_text_editors.delete(id)
+		g_text_kinds.delete(id)
+	}
+
 	// ── Public API ─────────────────────────────────────────────────────
 
 	pub fn bounds() Rect {
@@ -222,17 +279,21 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 	}
 
 	pub fn text(id string) string {
-		return g_text_values[id] or { '' }
+		// State maps store owned strings so that replacing their values can
+		// release the previous allocation. Callers, in particular QML bindings,
+		// may retain the returned value after the next edit, so give them their
+		// own copy rather than exposing the map's storage.
+		return (g_text_values[id] or { '' }).clone()
 	}
 
 	pub fn set_text(id string, t string) {
 		if id !in g_active_fields {
 			return
 		}
-		g_text_values[id] = t
-		mut editor := g_text_editors[id] or { text_editor(t) }
-		editor.set_text(t)
-		g_text_editors[id] = editor
+		replace_text_value(id, t)
+		mut editor := g_text_editors[id] or { text_editor(t.clone()) }
+		editor.set_text(t.clone())
+		replace_text_editor(id, editor)
 	}
 
 	// slider_value returns the live value currently displayed by a mounted
@@ -314,9 +375,9 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			return
 		}
 		g_focused_field = id
-		mut editor := g_text_editors[id] or { text_editor(g_text_values[id] or { '' }) }
+		mut editor := g_text_editors[id] or { text_editor((g_text_values[id] or { '' }).clone()) }
 		editor.set_caret(rune_len(editor.text))
-		g_text_editors[id] = editor
+		replace_text_editor(id, editor)
 	}
 
 	pub fn focused_id() string {
@@ -364,10 +425,10 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		if id !in g_active_fields || (g_text_kinds[id] or { Kind.screen }) != .text_area {
 			return
 		}
-		mut editor := g_text_editors[id] or { text_editor(g_text_values[id] or { '' }) }
+		mut editor := g_text_editors[id] or { text_editor((g_text_values[id] or { '' }).clone()) }
 		editor.insert_text(value)
-		g_text_editors[id] = editor
-		g_text_values[id] = editor.text
+		replace_text_value(id, editor.text)
+		replace_text_editor(id, editor)
 		fire_field_change(id)
 	}
 
@@ -741,16 +802,20 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		}
 		if target.text_field {
 			g_focused_field = target.id
-			mut editor := g_text_editors[target.id] or { text_editor(g_text_values[target.id] or { '' }) }
+			mut editor := g_text_editors[target.id] or {
+				text_editor((g_text_values[target.id] or { '' }).clone())
+			}
 			editor.set_caret(rune_len(editor.text))
-			g_text_editors[target.id] = editor
+			replace_text_editor(target.id, editor)
 			return
 		}
 		if target.text_area {
 			g_focused_field = target.id
-			mut editor := g_text_editors[target.id] or { text_editor(g_text_values[target.id] or { '' }) }
+			mut editor := g_text_editors[target.id] or {
+				text_editor((g_text_values[target.id] or { '' }).clone())
+			}
 			editor.set_caret(rune_len(editor.text))
-			g_text_editors[target.id] = editor
+			replace_text_editor(target.id, editor)
 			return
 		}
 		if target.dropdown {
@@ -945,11 +1010,11 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			return
 		}
 		mut editor := g_text_editors[g_focused_field] or {
-			text_editor(g_text_values[g_focused_field] or { '' })
+			text_editor((g_text_values[g_focused_field] or { '' }).clone())
 		}
 		editor.insert_text(rune(ch).str())
-		g_text_editors[g_focused_field] = editor
-		g_text_values[g_focused_field] = editor.text
+		replace_text_value(g_focused_field, editor.text)
+		replace_text_editor(g_focused_field, editor)
 		fire_field_change(g_focused_field)
 	}
 
@@ -958,19 +1023,19 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			return
 		}
 		mut editor := g_text_editors[g_focused_field] or {
-			text_editor(g_text_values[g_focused_field] or { '' })
+			text_editor((g_text_values[g_focused_field] or { '' }).clone())
 		}
 		if key == .backspace {
 			if editor.backspace() {
-				g_text_editors[g_focused_field] = editor
-				g_text_values[g_focused_field] = editor.text
+				replace_text_value(g_focused_field, editor.text)
+				replace_text_editor(g_focused_field, editor)
 				fire_field_change(g_focused_field)
 			}
 		}
 		if key == .delete {
 			if editor.delete_forward() {
-				g_text_editors[g_focused_field] = editor
-				g_text_values[g_focused_field] = editor.text
+				replace_text_value(g_focused_field, editor.text)
+				replace_text_editor(g_focused_field, editor)
 				fire_field_change(g_focused_field)
 			}
 		}
@@ -984,14 +1049,14 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			} else {
 				editor.set_caret(rune_len(editor.text))
 			}
-			g_text_editors[g_focused_field] = editor
+			replace_text_editor(g_focused_field, editor)
 		}
 		if key == .enter || key == .kp_enter {
 			for target in g_hit_targets {
 				if target.id == g_focused_field && target.text_area {
 					editor.insert_text('\n')
-					g_text_editors[g_focused_field] = editor
-					g_text_values[g_focused_field] = editor.text
+					replace_text_value(g_focused_field, editor.text)
+					replace_text_editor(g_focused_field, editor)
 					fire_field_change(g_focused_field)
 					return
 				}
@@ -1058,7 +1123,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 
 	fn commit_dropdown(id string, action_id string, value string) {
 		close_dropdown()
-		g_text_values[id] = value
+		replace_text_value(id, value)
 		fire_event(action_id)
 	}
 
@@ -1301,10 +1366,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			}
 		}
 		for id in stale_fields {
-			g_text_values.delete(id)
-			g_text_props.delete(id)
-			g_text_editors.delete(id)
-			g_text_kinds.delete(id)
+			forget_text_state(id)
 			forget_portable_text_area_selection(id)
 			if g_focused_field == id {
 				g_focused_field = ''
@@ -1581,9 +1643,11 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 				previous_prop := g_text_props[el.id] or { el.text }
 				kind_changed := el.id in g_text_kinds && (g_text_kinds[el.id] or { el.kind }) != el.kind
 				if kind_changed || el.id !in g_text_values || (el.text != previous_prop && (g_text_values[el.id] or { '' }) != el.text) {
-					g_text_values[el.id] = el.text
+					replace_text_value(el.id, el.text)
 				}
-				g_text_props[el.id] = el.text
+				if el.id !in g_text_props || el.text != previous_prop {
+					replace_text_prop(el.id, el.text)
+				}
 				g_text_kinds[el.id] = el.kind
 				g_active_fields[el.id] = true
 				selected := g_text_values[el.id] or { el.text }
@@ -1635,17 +1699,19 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 				previous_prop := g_text_props[el.id] or { el.text }
 				kind_changed := el.id in g_text_kinds && (g_text_kinds[el.id] or { el.kind }) != el.kind
 				if kind_changed || el.id !in g_text_values || (el.text != previous_prop && (g_text_values[el.id] or { '' }) != el.text) {
-					g_text_values[el.id] = el.text
-					g_text_editors[el.id] = text_editor(el.text)
+					replace_text_value(el.id, el.text)
+					replace_text_editor(el.id, text_editor(el.text.clone()))
 				}
-				g_text_props[el.id] = el.text
+				if el.id !in g_text_props || el.text != previous_prop {
+					replace_text_prop(el.id, el.text)
+				}
 				g_text_kinds[el.id] = el.kind
 				g_active_fields[el.id] = true
 				current_text := g_text_values[el.id] or { el.text }
-				mut editor := g_text_editors[el.id] or { text_editor(current_text) }
+				mut editor := g_text_editors[el.id] or { text_editor(current_text.clone()) }
 				if editor.text != current_text {
-					editor.set_text(current_text)
-					g_text_editors[el.id] = editor
+					editor.set_text(current_text.clone())
+					replace_text_editor(el.id, editor)
 				}
 				display_text := text_field_display_text(current_text, el.secure)
 				is_focused := g_focused_field == el.id
@@ -1689,10 +1755,12 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 				previous_prop := g_text_props[el.id] or { el.text }
 				kind_changed := el.id in g_text_kinds && (g_text_kinds[el.id] or { el.kind }) != el.kind
 				if kind_changed || el.id !in g_text_values || (el.text != previous_prop && (g_text_values[el.id] or { '' }) != el.text) {
-					g_text_values[el.id] = el.text
-					g_text_editors[el.id] = text_editor(el.text)
+					replace_text_value(el.id, el.text)
+					replace_text_editor(el.id, text_editor(el.text.clone()))
 				}
-				g_text_props[el.id] = el.text
+				if el.id !in g_text_props || el.text != previous_prop {
+					replace_text_prop(el.id, el.text)
+				}
 				g_text_kinds[el.id] = el.kind
 				g_active_fields[el.id] = true
 				current_text := g_text_values[el.id] or { el.text }

--- a/ui/ui_text_selection_immediate.c.v
+++ b/ui/ui_text_selection_immediate.c.v
@@ -8,11 +8,11 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		value := text(id)
 		selection := clamped_text_area_selection(value, location, length)
 		record_portable_text_area_selection(id, selection)
-		mut editor := g_text_editors[id] or { text_editor(value) }
+		mut editor := g_text_editors[id] or { text_editor(value.clone()) }
 		start := utf16_offset_to_rune_index(value, selection.location)
 		end := utf16_offset_to_rune_index(value, selection.location + selection.length)
 		editor.set_selection(start, end)
-		g_text_editors[id] = editor
+		replace_text_editor(id, editor)
 	}
 
 	pub fn text_area_set_caret(id string, pos int) {


### PR DESCRIPTION
## Summary
- release replaced custom-renderer text state instead of retaining one allocation per edit
- keep editor, live value, and declared text state independently owned
- release temporary rune-edit buffers and cover caret movement plus delete/type editing

## Verification
- `/Users/alex/code/v3/v test ui/text_editor_test.v`
- `/Users/alex/code/v3/v -d ui2_custom_rendering test ui/ui_custom_test.v`
- `/Users/alex/code/v3/v -d ui2_custom_rendering test ui/ui_scroll_immediate_test.v`
- `/Users/alex/code/v3/v -d ui2_custom_rendering -shared -os linux -check .`

Closes #6