### PR TITLE
Add native file and folder dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,43 @@ MessageBox {
 }
 ```
 
+## File and folder dialogs
+
+`open_file_dialog`, `save_file_dialog`, and `open_folder_dialog` show the
+operating system picker and return the selected absolute paths. They block while
+the picker is open; cancellation is an empty array. `open_file_dialog` can
+return several paths when `multiple: true`.
+
+```v
+paths := ui2.open_file_dialog(
+	title: 'Open a V source file'
+	directory: '/work/project'
+	filters: [ui2.FileDialogFilter{
+		name: 'V source'
+		extensions: ['v', 'vv']
+	}]
+)
+if paths.len > 0 {
+	println('Opening ${paths[0]}')
+}
+
+destination := ui2.save_file_dialog(
+	title: 'Save report'
+	filename: 'report.txt'
+	filters: [ui2.FileDialogFilter{
+		name: 'Text'
+		extensions: ['txt']
+	}]
+)
+```
+
+The API uses `NSOpenPanel`/`NSSavePanel` on macOS, standard Win32 open/save
+and folder dialogs on Windows, and the desktop's `zenity` or `kdialog` picker
+on Linux. Linux requires a graphical session and one of those helpers;
+`file_dialog_supported()` reports that availability. The synchronous API is not
+available on iOS or Android, where a document picker needs an app-specific
+asynchronous presentation callback.
+
 ## Menus and the tray
 
 `set_menu_bar(...)` installs the application's top level menu bar and

--- a/examples/file_dialog/file_dialog.qml
+++ b/examples/file_dialog/file_dialog.qml
@@ -1,0 +1,23 @@
+Screen {
+    id: root
+    background: #F1F5F9
+
+    Rectangle {
+        id: card
+        x: 16
+        y: 16
+        width: root.width - 32
+        height: root.height - 32
+        background: #FFFFFF
+        corner_radius: 10
+
+        Label { text: "Native file and folder dialogs" x: 20 y: 22 width: card.width - 40 height: 28 color: #111827 font_size: 20 bold: true }
+        Label { text: "Each action opens the operating system picker and blocks until it closes." x: 20 y: 56 width: card.width - 40 height: 20 color: #64748B font_size: 12 }
+
+        Button { id: open_source text: "Open source" on_tap: app.open_source() native: true x: 20 y: 98 width: 160 height: 38 }
+        Button { id: save_text text: "Save text" on_tap: app.save_text() native: true x: 194 y: 98 width: 160 height: 38 }
+        Button { id: choose_folder text: "Choose folder" on_tap: app.choose_folder() native: true x: 368 y: 98 width: 160 height: 38 }
+
+        Label { id: selection text: app.selection x: 20 y: 166 width: card.width - 40 height: 48 color: #166534 font_size: 12 }
+    }
+}

--- a/examples/file_dialog/file_dialog_test.v
+++ b/examples/file_dialog/file_dialog_test.v
@@ -1,0 +1,9 @@
+module main
+
+import ui2
+
+fn test_file_dialog_example_declares_native_actions() {
+	root := ui2.element_from_qml_model(file_dialog_qml_source, FileDialogDemo{}, ui2.rect(0, 0, file_dialog_width, file_dialog_height)) or { panic(err) }
+	ui2.validate_element_tree(root) or { panic(err) }
+	assert root.id == 'root'
+}

--- a/examples/file_dialog/file_dialog_test.v
+++ b/examples/file_dialog/file_dialog_test.v
@@ -3,7 +3,7 @@ module main
 import ui2
 
 fn test_file_dialog_example_declares_native_actions() {
-	root := ui2.element_from_qml_model(file_dialog_qml_source, FileDialogDemo{}, ui2.rect(0, 0, file_dialog_width, file_dialog_height)) or { panic(err) }
+	root := ui2.element_from_vml_model(file_dialog_qml_source, FileDialogDemo{}, ui2.rect(0, 0, file_dialog_width, file_dialog_height)) or { panic(err) }
 	ui2.validate_element_tree(root) or { panic(err) }
 	assert root.id == 'root'
 }

--- a/examples/file_dialog/main.v
+++ b/examples/file_dialog/main.v
@@ -1,0 +1,60 @@
+module main
+
+import os
+import ui2
+
+const file_dialog_width = 620
+const file_dialog_height = 290
+const file_dialog_qml_source = $embed_file('file_dialog.qml').to_string()
+
+pub struct FileDialogDemo {
+pub mut:
+	selection string = 'Choose a file, a destination, or a folder.'
+}
+
+pub fn (mut app FileDialogDemo) open_source() {
+	paths := ui2.open_file_dialog(
+		title: 'Open a V source file'
+		filters: [
+			ui2.FileDialogFilter{
+				name: 'V source'
+				extensions: ['v', 'vv']
+			},
+		]
+	)
+	app.selection = if paths.len > 0 { 'Open: ${paths[0]}' } else { 'Open cancelled.' }
+}
+
+pub fn (mut app FileDialogDemo) save_text() {
+	paths := ui2.save_file_dialog(
+		title: 'Save text file'
+		filename: 'notes.txt'
+		filters: [ui2.FileDialogFilter{
+			name: 'Text'
+			extensions: ['txt']
+		}]
+	)
+	app.selection = if paths.len > 0 { 'Save: ${paths[0]}' } else { 'Save cancelled.' }
+}
+
+pub fn (mut app FileDialogDemo) choose_folder() {
+	paths := ui2.open_folder_dialog(
+		title: 'Choose a folder'
+		directory: os.home_dir()
+	)
+	app.selection = if paths.len > 0 {
+		'Folder: ${paths[0]}'
+	} else {
+		'Folder selection cancelled.'
+	}
+}
+
+fn main() {
+	ui2.run_qml[FileDialogDemo](
+		source: file_dialog_qml_source
+		model: FileDialogDemo{}
+		title: 'Native file dialog'
+		width: file_dialog_width
+		height: file_dialog_height
+	) or { panic(err) }
+}

--- a/examples/file_dialog/main.v
+++ b/examples/file_dialog/main.v
@@ -50,7 +50,7 @@ pub fn (mut app FileDialogDemo) choose_folder() {
 }
 
 fn main() {
-	ui2.run_qml[FileDialogDemo](
+	ui2.run_vml[FileDialogDemo](
 		source: file_dialog_qml_source
 		model: FileDialogDemo{}
 		title: 'Native file dialog'

--- a/ui/file_dialog.v
+++ b/ui/file_dialog.v
@@ -1,0 +1,143 @@
+module ui2
+
+// FileDialogKind selects which platform picker to show.
+pub enum FileDialogKind {
+	open
+	save
+	folder
+}
+
+// FileDialogFilter gives a file type a user-facing name and its filename
+// extensions. Extensions may be written as `v`, `.v`, or `*.v`.
+pub struct FileDialogFilter {
+pub:
+	name       string
+	extensions []string
+}
+
+// FileDialogConfig configures a synchronous platform file picker. `directory`
+// is the initial folder when the platform supports it, and `filename` is the
+// proposed name for save dialogs. `multiple` applies only to open dialogs.
+pub struct FileDialogConfig {
+pub:
+	kind      FileDialogKind = .open
+	title     string
+	directory string
+	filename  string
+	filters   []FileDialogFilter
+	multiple  bool
+}
+
+// file_dialog opens the operating system's own file picker and blocks until it
+// is accepted or dismissed. An empty result means that the user cancelled, or
+// that this target has no native picker. Check file_dialog_supported when those
+// cases must be distinguished.
+pub fn file_dialog(cfg FileDialogConfig) []string {
+	return native_file_dialog(cfg)
+}
+
+// file_dialog_supported reports whether this target can display a native file
+// picker. macOS, Windows, and Linux desktop sessions with zenity or kdialog
+// are supported; mobile and headless fallback targets return false.
+pub fn file_dialog_supported() bool {
+	return native_file_dialog_supported()
+}
+
+// open_file_dialog selects one file, or several when cfg.multiple is true.
+pub fn open_file_dialog(cfg FileDialogConfig) []string {
+	return native_file_dialog(open_file_dialog_config(cfg))
+}
+
+fn open_file_dialog_config(cfg FileDialogConfig) FileDialogConfig {
+	return FileDialogConfig{
+		kind: .open
+		title: cfg.title
+		directory: cfg.directory
+		filename: cfg.filename
+		filters: cfg.filters
+		multiple: cfg.multiple
+	}
+}
+
+// save_file_dialog asks for a destination filename. It returns either one path
+// or no paths when dismissed.
+pub fn save_file_dialog(cfg FileDialogConfig) []string {
+	return native_file_dialog(save_file_dialog_config(cfg))
+}
+
+fn save_file_dialog_config(cfg FileDialogConfig) FileDialogConfig {
+	return FileDialogConfig{
+		kind: .save
+		title: cfg.title
+		directory: cfg.directory
+		filename: cfg.filename
+		filters: cfg.filters
+	}
+}
+
+// open_folder_dialog selects one existing folder. File filters and `multiple`
+// do not apply to folder dialogs.
+pub fn open_folder_dialog(cfg FileDialogConfig) []string {
+	return native_file_dialog(open_folder_dialog_config(cfg))
+}
+
+fn open_folder_dialog_config(cfg FileDialogConfig) FileDialogConfig {
+	return FileDialogConfig{
+		kind: .folder
+		title: cfg.title
+		directory: cfg.directory
+	}
+}
+
+// file_dialog_extensions normalizes the common extension notation before it is
+// handed to native filter APIs. It preserves first-seen order and ignores the
+// wildcard, because an unrestricted picker needs no explicit type filter.
+fn file_dialog_extensions(filters []FileDialogFilter) []string {
+	mut seen := map[string]bool{}
+	mut result := []string{}
+	for filter in filters {
+		for extension in filter.extensions {
+			mut clean := extension.trim_space()
+			if clean.starts_with('*.') {
+				clean = clean[2..]
+			} else if clean.starts_with('.') {
+				clean = clean[1..]
+			}
+			if clean.len == 0 || clean == '*' || clean == '*.*' || seen[clean] {
+				continue
+			}
+			seen[clean] = true
+			result << clean
+		}
+	}
+	return result
+}
+
+// file_dialog_filter_spec is the label/pattern representation expected by the
+// Windows backend. It is deliberately plain text so each backend can map the
+// same public filters onto its own native control.
+fn file_dialog_filter_spec(filters []FileDialogFilter) string {
+	mut parts := []string{}
+	for filter in filters {
+		mut patterns := []string{}
+		for extension in filter.extensions {
+			mut clean := extension.trim_space()
+			if clean.starts_with('*.') {
+				clean = clean[2..]
+			} else if clean.starts_with('.') {
+				clean = clean[1..]
+			}
+			if clean.len > 0 && clean != '*' && clean != '*.*' {
+				patterns << '*.' + clean
+			}
+		}
+		if patterns.len > 0 {
+			filter_name := if filter.name.len > 0 { filter.name } else { patterns.join(', ') }
+			parts << filter_name
+			parts << patterns.join(';')
+		}
+	}
+	parts << 'All files'
+	parts << '*.*'
+	return parts.join('|')
+}

--- a/ui/file_dialog_darwin.v
+++ b/ui/file_dialog_darwin.v
@@ -1,0 +1,76 @@
+// vfmt off
+module ui2
+
+import macos
+
+#flag darwin -framework AppKit
+
+const ns_modal_response_ok = i64(1)
+
+fn native_file_dialog_supported() bool {
+	return true
+}
+
+fn native_file_dialog(cfg FileDialogConfig) []string {
+	pool := macos.autorelease_pool_new()
+	defer {
+		macos.release(pool)
+	}
+	macos.msg_id(macos.get_class('NSApplication'), 'sharedApplication')
+	panel := if cfg.kind == .save {
+		macos.msg_id(macos.get_class('NSSavePanel'), 'savePanel')
+	} else {
+		macos.msg_id(macos.get_class('NSOpenPanel'), 'openPanel')
+	}
+	if panel == unsafe { nil } {
+		return []string{}
+	}
+	if cfg.title.len > 0 {
+		macos.msg_void1(panel, 'setTitle:', macos.nsstring(cfg.title))
+	}
+	if cfg.directory.len > 0 {
+		url := macos.msg_id1(macos.get_class('NSURL'), 'fileURLWithPath:',
+			macos.nsstring(cfg.directory))
+		macos.msg_void1(panel, 'setDirectoryURL:', url)
+	}
+	if cfg.kind == .save {
+		macos.msg_void_bool(panel, 'setCanCreateDirectories:', true)
+		if cfg.filename.len > 0 {
+			macos.msg_void1(panel, 'setNameFieldStringValue:', macos.nsstring(cfg.filename))
+		}
+	} else {
+		macos.msg_void_bool(panel, 'setCanChooseFiles:', cfg.kind == .open)
+		macos.msg_void_bool(panel, 'setCanChooseDirectories:', cfg.kind == .folder)
+		macos.msg_void_bool(panel, 'setAllowsMultipleSelection:', cfg.kind == .open && cfg.multiple)
+	}
+	extensions := file_dialog_extensions(cfg.filters)
+	if cfg.kind != .folder && extensions.len > 0 {
+		allowed := macos.msg_id(macos.alloc('NSMutableArray'), 'init')
+		for extension in extensions {
+			macos.msg_void1(allowed, 'addObject:', macos.nsstring(extension))
+		}
+		macos.msg_void1(panel, 'setAllowedFileTypes:', allowed)
+		macos.release(allowed)
+	}
+	if macos.msg_i64(panel, 'runModal') != ns_modal_response_ok {
+		return []string{}
+	}
+	if cfg.kind == .save {
+		path := native_file_dialog_macos_url_path(macos.msg_id(panel, 'URL'))
+		return if path.len > 0 { [path] } else { []string{} }
+	}
+	urls := macos.msg_id(panel, 'URLs')
+	mut paths := []string{}
+	for index in 0 .. int(macos.msg_u64(urls, 'count')) {
+		paths << native_file_dialog_macos_url_path(macos.msg_id_u64(urls, 'objectAtIndex:',
+			u64(index)))
+	}
+	return paths.filter(it.len > 0)
+}
+
+fn native_file_dialog_macos_url_path(url macos.Id) string {
+	if url == unsafe { nil } {
+		return ''
+	}
+	return macos.utf8_string(macos.msg_id(url, 'path'))
+}

--- a/ui/file_dialog_default.c.v
+++ b/ui/file_dialog_default.c.v
@@ -1,0 +1,12 @@
+// Fallback for targets whose platform dialog needs a UI callback this layer
+// cannot install, including Android and iOS.
+module ui2
+
+fn native_file_dialog_supported() bool {
+	return false
+}
+
+fn native_file_dialog(cfg FileDialogConfig) []string {
+	eprintln('ui2: native file dialogs are unavailable on this target')
+	return []string{}
+}

--- a/ui/file_dialog_ios.v
+++ b/ui/file_dialog_ios.v
@@ -1,0 +1,12 @@
+module ui2
+
+// UIKit document pickers are asynchronous and require a presentation callback.
+// Keep the synchronous desktop API explicit about not supporting that contract.
+fn native_file_dialog_supported() bool {
+	return false
+}
+
+fn native_file_dialog(cfg FileDialogConfig) []string {
+	eprintln('ui2: native file dialogs are unavailable on iOS')
+	return []string{}
+}

--- a/ui/file_dialog_linux.v
+++ b/ui/file_dialog_linux.v
@@ -1,0 +1,140 @@
+module ui2
+
+import os
+
+fn linux_file_dialog_tool() string {
+	if os.getenv('DISPLAY').len == 0 && os.getenv('WAYLAND_DISPLAY').len == 0 {
+		return ''
+	}
+	desktop := os.getenv('XDG_CURRENT_DESKTOP').to_lower()
+	preferred := if desktop.contains('kde') || desktop.contains('plasma') {
+		['kdialog', 'zenity']
+	} else {
+		['zenity', 'kdialog']
+	}
+	for tool in preferred {
+		if os.find_abs_path_of_executable(tool) or { '' }.len > 0 {
+			return tool
+		}
+	}
+	return ''
+}
+
+fn native_file_dialog_supported() bool {
+	return linux_file_dialog_tool().len > 0
+}
+
+fn native_file_dialog(cfg FileDialogConfig) []string {
+	tool := linux_file_dialog_tool()
+	command := match tool {
+		'zenity' { linux_zenity_file_dialog_command(cfg) }
+		'kdialog' { linux_kdialog_file_dialog_command(cfg) }
+		else { '' }
+	}
+	if command.len == 0 {
+		eprintln('ui2: no native file dialog is available')
+		return []string{}
+	}
+	result := os.execute(command)
+	if result.exit_code != 0 {
+		return []string{}
+	}
+	return linux_file_dialog_paths(result.output)
+}
+
+fn linux_file_dialog_start_path(cfg FileDialogConfig) string {
+	if cfg.filename.len == 0 {
+		return cfg.directory
+	}
+	if cfg.directory.len == 0 {
+		return cfg.filename
+	}
+	return if cfg.directory.ends_with('/') {
+		cfg.directory + cfg.filename
+	} else {
+		cfg.directory + '/' + cfg.filename
+	}
+}
+
+fn linux_zenity_file_dialog_command(cfg FileDialogConfig) string {
+	mut parts := ['zenity', '--file-selection']
+	if cfg.kind == .save {
+		parts << ['--save', '--confirm-overwrite']
+	}
+	if cfg.kind == .folder {
+		parts << '--directory'
+	}
+	if cfg.kind == .open && cfg.multiple {
+		parts << ['--multiple', '--separator=' + linux_shell_quote('\n')]
+	}
+	if cfg.title.len > 0 {
+		parts << '--title=' + linux_shell_quote(cfg.title)
+	}
+	start := linux_file_dialog_start_path(cfg)
+	if start.len > 0 {
+		parts << '--filename=' + linux_shell_quote(start)
+	}
+	if cfg.kind != .folder {
+		for filter in cfg.filters {
+			mut patterns := []string{}
+			for extension in file_dialog_extensions([filter]) {
+				patterns << '*.' + extension
+			}
+			if patterns.len > 0 {
+				filter_name := if filter.name.len > 0 { filter.name } else { patterns.join(', ') }
+				parts << '--file-filter=' + linux_shell_quote('${filter_name} | ${patterns.join(' ')}')
+			}
+		}
+	}
+	return parts.join(' ')
+}
+
+fn linux_kdialog_file_dialog_command(cfg FileDialogConfig) string {
+	mut parts := ['kdialog']
+	if cfg.title.len > 0 {
+		parts << ['--title', linux_shell_quote(cfg.title)]
+	}
+	start := linux_file_dialog_start_path(cfg)
+	filter := linux_kdialog_file_filter(cfg.filters)
+	match cfg.kind {
+		.open {
+			parts << ['--getopenfilename', linux_shell_quote(start), linux_shell_quote(filter)]
+			if cfg.multiple {
+				parts << ['--multiple', '--separate-output']
+			}
+		}
+		.save {
+			parts << ['--getsavefilename', linux_shell_quote(start), linux_shell_quote(filter)]
+		}
+		.folder {
+			parts << ['--getexistingdirectory', linux_shell_quote(cfg.directory)]
+		}
+	}
+	return parts.join(' ')
+}
+
+fn linux_kdialog_file_filter(filters []FileDialogFilter) string {
+	mut entries := []string{}
+	for filter in filters {
+		mut patterns := []string{}
+		for extension in file_dialog_extensions([filter]) {
+			patterns << '*.' + extension
+		}
+		if patterns.len > 0 {
+			filter_name := if filter.name.len > 0 { filter.name } else { patterns.join(', ') }
+			entries << '${patterns.join(' ')}|${filter_name}'
+		}
+	}
+	return entries.join('\n')
+}
+
+fn linux_file_dialog_paths(output string) []string {
+	mut paths := []string{}
+	for raw in output.split('\n') {
+		path := raw.trim_right('\r')
+		if path.len > 0 {
+			paths << path
+		}
+	}
+	return paths
+}

--- a/ui/file_dialog_test.v
+++ b/ui/file_dialog_test.v
@@ -1,0 +1,42 @@
+module ui2
+
+fn test_file_dialog_normalizes_extensions_and_deduplicates_them() {
+	filters := [
+		FileDialogFilter{
+			name: 'V source'
+			extensions: ['v', '.v', '*.vv', '*.*']
+		},
+		FileDialogFilter{
+			name: 'Text'
+			extensions: ['txt', ' .md ']
+		},
+	]
+	assert file_dialog_extensions(filters) == ['v', 'vv', 'txt', 'md']
+}
+
+fn test_file_dialog_filter_spec_uses_native_wildcards_and_has_a_fallback() {
+	assert file_dialog_filter_spec([
+		FileDialogFilter{
+			name: 'V source'
+			extensions: ['v', '.vv']
+		},
+	]) == 'V source|*.v;*.vv|All files|*.*'
+	assert file_dialog_filter_spec([]) == 'All files|*.*'
+}
+
+fn test_file_dialog_convenience_functions_choose_their_expected_kind() {
+	text_filter := FileDialogFilter{
+		name: 'Text'
+		extensions: ['txt']
+	}
+	cfg := FileDialogConfig{
+		title: 'Choose a document'
+		directory: '/tmp'
+		filename: 'draft.txt'
+		multiple: true
+		filters: [text_filter]
+	}
+	assert open_file_dialog_config(cfg).kind == .open
+	assert save_file_dialog_config(cfg).kind == .save
+	assert open_folder_dialog_config(cfg).kind == .folder
+}

--- a/ui/file_dialog_windows.c.v
+++ b/ui/file_dialog_windows.c.v
@@ -1,0 +1,42 @@
+// vfmt off
+module ui2
+
+#flag windows -lcomdlg32
+#flag windows -lshell32
+#flag windows -lole32
+
+#insert "@VMODROOT/windows/file_dialog_windows.h"
+
+// A multi-select response repeats the containing folder for every result on
+// the V side, so leave room for up to twice the native common-dialog buffer.
+const file_dialog_windows_buffer_size = 65536
+
+fn C.ui2_win_file_dialog(output &u16, output_capacity u32, title &u16, directory &u16, filename &u16, filter_spec &u16, kind int, multiple int) int
+
+fn native_file_dialog_supported() bool {
+	return true
+}
+
+fn native_file_dialog(cfg FileDialogConfig) []string {
+	mut output := []u16{len: file_dialog_windows_buffer_size}
+	title := cfg.title.to_wide()
+	directory := cfg.directory.to_wide()
+	filename := cfg.filename.to_wide()
+	filter_spec := file_dialog_filter_spec(cfg.filters).to_wide()
+	accepted := C.ui2_win_file_dialog(unsafe { &output[0] }, file_dialog_windows_buffer_size,
+		title, directory, filename, filter_spec, int(cfg.kind), if cfg.kind == .open && cfg.multiple {
+		1
+	} else {
+		0
+	})
+	unsafe {
+		free(title)
+		free(directory)
+		free(filename)
+		free(filter_spec)
+	}
+	if accepted == 0 || output[0] == 0 {
+		return []string{}
+	}
+	return unsafe { string_from_wide(&output[0]) }.split('\n')
+}

--- a/ui/file_dialog_windows.c.v
+++ b/ui/file_dialog_windows.c.v
@@ -1,14 +1,17 @@
 // vfmt off
 module ui2
 
+import os
+
 #flag windows -lcomdlg32
 #flag windows -lshell32
 #flag windows -lole32
 
 #insert "@VMODROOT/windows/file_dialog_windows.h"
 
-// A multi-select response repeats the containing folder for every result on
-// the V side, so leave room for up to twice the native common-dialog buffer.
+// The native common dialog uses a maximum 32,768 UTF-16 character result
+// buffer. Multi-select responses retain that compact folder-plus-filenames
+// representation until V expands it below.
 const file_dialog_windows_buffer_size = 65536
 
 fn C.ui2_win_file_dialog(output &u16, output_capacity u32, title &u16, directory &u16, filename &u16, filter_spec &u16, kind int, multiple int) int
@@ -38,5 +41,9 @@ fn native_file_dialog(cfg FileDialogConfig) []string {
 	if accepted == 0 || output[0] == 0 {
 		return []string{}
 	}
-	return unsafe { string_from_wide(&output[0]) }.split('\n')
+	paths := unsafe { string_from_wide(&output[0]) }.split('\n')
+	if cfg.kind == .open && cfg.multiple && paths.len > 1 {
+		return paths[1..].map(os.join_path(paths[0], it))
+	}
+	return paths
 }

--- a/windows/file_dialog_windows.h
+++ b/windows/file_dialog_windows.h
@@ -1,0 +1,121 @@
+#ifndef UI2_FILE_DIALOG_WINDOWS_H
+#define UI2_FILE_DIALOG_WINDOWS_H
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+#ifndef _UNICODE
+#define _UNICODE
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601
+#endif
+
+#include <windows.h>
+#include <commdlg.h>
+#include <shlobj.h>
+#include <wchar.h>
+
+enum {
+	UI2_FILE_DIALOG_OPEN = 0,
+	UI2_FILE_DIALOG_SAVE = 1,
+	UI2_FILE_DIALOG_FOLDER = 2
+};
+
+static inline HWND ui2_win_file_dialog_owner(void) {
+	HWND owner = GetActiveWindow();
+	return owner == NULL ? GetForegroundWindow() : owner;
+}
+
+static inline size_t ui2_win_file_dialog_append(wchar_t *output, size_t capacity,
+		size_t used, const wchar_t *value) {
+	if (value == NULL || capacity == 0 || used >= capacity) return used;
+	while (*value != 0 && used + 1 < capacity) output[used++] = *value++;
+	output[used] = 0;
+	return used;
+}
+
+static inline void ui2_win_file_dialog_filter(wchar_t *output, size_t capacity,
+		const wchar_t *spec) {
+	size_t index = 0;
+	if (spec != NULL) {
+		while (*spec != 0 && index + 2 < capacity) {
+			output[index++] = *spec == L'|' ? 0 : *spec;
+			spec++;
+		}
+	}
+	if (index == 0) {
+		const wchar_t fallback[] = L"All files\0*.*\0\0";
+		for (size_t i = 0; i < sizeof(fallback) / sizeof(fallback[0]) && i < capacity; i++) output[i] = fallback[i];
+		return;
+	}
+	output[index++] = 0;
+	output[index] = 0;
+}
+
+static inline int ui2_win_file_dialog_folder(wchar_t *output, unsigned int capacity,
+		const wchar_t *title) {
+	BROWSEINFOW info;
+	ZeroMemory(&info, sizeof(info));
+	info.hwndOwner = ui2_win_file_dialog_owner();
+	info.lpszTitle = title == NULL ? L"" : title;
+	info.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+	PIDLIST_ABSOLUTE item = SHBrowseForFolderW(&info);
+	if (item == NULL) return 0;
+	BOOL ok = SHGetPathFromIDListW(item, output);
+	CoTaskMemFree(item);
+	return ok && output[0] != 0;
+}
+
+// ui2_win_file_dialog writes selected paths as newline-separated UTF-16. A
+// newline is not legal in Windows path components, so it is an unambiguous
+// bridge representation for V while keeping all native selection parsing here.
+static inline int ui2_win_file_dialog(wchar_t *output, unsigned int output_capacity,
+		const wchar_t *title, const wchar_t *directory, const wchar_t *filename,
+		const wchar_t *filter_spec, int kind, int multiple) {
+	if (output == NULL || output_capacity < 2) return 0;
+	output[0] = 0;
+	if (kind == UI2_FILE_DIALOG_FOLDER) return ui2_win_file_dialog_folder(output, output_capacity, title);
+
+	wchar_t selected[32768];
+	wchar_t filter[8192];
+	ZeroMemory(selected, sizeof(selected));
+	ZeroMemory(filter, sizeof(filter));
+	if (filename != NULL) wcsncpy(selected, filename, (sizeof(selected) / sizeof(selected[0])) - 1);
+	ui2_win_file_dialog_filter(filter, sizeof(filter) / sizeof(filter[0]), filter_spec);
+
+	OPENFILENAMEW info;
+	ZeroMemory(&info, sizeof(info));
+	info.lStructSize = sizeof(info);
+	info.hwndOwner = ui2_win_file_dialog_owner();
+	info.lpstrFilter = filter;
+	info.lpstrFile = selected;
+	info.nMaxFile = sizeof(selected) / sizeof(selected[0]);
+	info.lpstrInitialDir = directory != NULL && directory[0] != 0 ? directory : NULL;
+	info.lpstrTitle = title != NULL && title[0] != 0 ? title : NULL;
+	info.Flags = OFN_EXPLORER | OFN_NOCHANGEDIR | OFN_PATHMUSTEXIST;
+	if (kind == UI2_FILE_DIALOG_OPEN) info.Flags |= OFN_FILEMUSTEXIST;
+	if (kind == UI2_FILE_DIALOG_OPEN && multiple) info.Flags |= OFN_ALLOWMULTISELECT;
+	if (!(kind == UI2_FILE_DIALOG_SAVE ? GetSaveFileNameW(&info) : GetOpenFileNameW(&info))) return 0;
+
+	wchar_t *next = selected + wcslen(selected) + 1;
+	if (*next == 0) {
+		ui2_win_file_dialog_append(output, output_capacity, 0, selected);
+		return output[0] != 0;
+	}
+	size_t used = 0;
+	const size_t folder_length = wcslen(selected);
+	while (*next != 0) {
+		if (used > 0 && used + 1 < output_capacity) output[used++] = L'\n';
+		used = ui2_win_file_dialog_append(output, output_capacity, used, selected);
+		if (folder_length > 0 && selected[folder_length - 1] != L'\\' && used + 1 < output_capacity) output[used++] = L'\\';
+		used = ui2_win_file_dialog_append(output, output_capacity, used, next);
+		next += wcslen(next) + 1;
+	}
+	return output[0] != 0;
+}
+
+#endif

--- a/windows/file_dialog_windows.h
+++ b/windows/file_dialog_windows.h
@@ -30,12 +30,14 @@ static inline HWND ui2_win_file_dialog_owner(void) {
 	return owner == NULL ? GetForegroundWindow() : owner;
 }
 
-static inline size_t ui2_win_file_dialog_append(wchar_t *output, size_t capacity,
-		size_t used, const wchar_t *value) {
-	if (value == NULL || capacity == 0 || used >= capacity) return used;
-	while (*value != 0 && used + 1 < capacity) output[used++] = *value++;
-	output[used] = 0;
-	return used;
+static inline int ui2_win_file_dialog_append(wchar_t *output, size_t capacity,
+		size_t *used, const wchar_t *value) {
+	size_t value_length = value == NULL ? 0 : wcslen(value);
+	if (capacity == 0 || *used + value_length >= capacity) return 0;
+	if (value_length > 0) wmemcpy(output + *used, value, value_length);
+	*used += value_length;
+	output[*used] = 0;
+	return 1;
 }
 
 static inline void ui2_win_file_dialog_filter(wchar_t *output, size_t capacity,
@@ -56,29 +58,43 @@ static inline void ui2_win_file_dialog_filter(wchar_t *output, size_t capacity,
 	output[index] = 0;
 }
 
+static int CALLBACK ui2_win_file_dialog_folder_callback(HWND window, UINT message,
+		LPARAM lparam, LPARAM data) {
+	if (message == BFFM_INITIALIZED && data != 0) {
+		SendMessageW(window, BFFM_SETSELECTIONW, TRUE, data);
+	}
+	return 0;
+}
+
 static inline int ui2_win_file_dialog_folder(wchar_t *output, unsigned int capacity,
-		const wchar_t *title) {
+		const wchar_t *title, const wchar_t *directory) {
+	HRESULT com_result = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
 	BROWSEINFOW info;
 	ZeroMemory(&info, sizeof(info));
 	info.hwndOwner = ui2_win_file_dialog_owner();
 	info.lpszTitle = title == NULL ? L"" : title;
-	info.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+	info.ulFlags = BIF_RETURNONLYFSDIRS;
+	if (SUCCEEDED(com_result)) info.ulFlags |= BIF_NEWDIALOGSTYLE;
+	if (directory != NULL && directory[0] != 0) {
+		info.lpfn = ui2_win_file_dialog_folder_callback;
+		info.lParam = (LPARAM)directory;
+	}
 	PIDLIST_ABSOLUTE item = SHBrowseForFolderW(&info);
-	if (item == NULL) return 0;
-	BOOL ok = SHGetPathFromIDListW(item, output);
-	CoTaskMemFree(item);
+	BOOL ok = item != NULL && SHGetPathFromIDListW(item, output);
+	if (item != NULL) CoTaskMemFree(item);
+	if (SUCCEEDED(com_result)) CoUninitialize();
 	return ok && output[0] != 0;
 }
 
 // ui2_win_file_dialog writes selected paths as newline-separated UTF-16. A
-// newline is not legal in Windows path components, so it is an unambiguous
-// bridge representation for V while keeping all native selection parsing here.
+// multi-select result keeps Windows' compact folder-plus-filenames form; the
+// V bridge expands that form without risking a truncated final path.
 static inline int ui2_win_file_dialog(wchar_t *output, unsigned int output_capacity,
 		const wchar_t *title, const wchar_t *directory, const wchar_t *filename,
 		const wchar_t *filter_spec, int kind, int multiple) {
 	if (output == NULL || output_capacity < 2) return 0;
 	output[0] = 0;
-	if (kind == UI2_FILE_DIALOG_FOLDER) return ui2_win_file_dialog_folder(output, output_capacity, title);
+	if (kind == UI2_FILE_DIALOG_FOLDER) return ui2_win_file_dialog_folder(output, output_capacity, title, directory);
 
 	wchar_t selected[32768];
 	wchar_t filter[8192];
@@ -98,21 +114,22 @@ static inline int ui2_win_file_dialog(wchar_t *output, unsigned int output_capac
 	info.lpstrTitle = title != NULL && title[0] != 0 ? title : NULL;
 	info.Flags = OFN_EXPLORER | OFN_NOCHANGEDIR | OFN_PATHMUSTEXIST;
 	if (kind == UI2_FILE_DIALOG_OPEN) info.Flags |= OFN_FILEMUSTEXIST;
+	if (kind == UI2_FILE_DIALOG_SAVE) info.Flags |= OFN_OVERWRITEPROMPT;
 	if (kind == UI2_FILE_DIALOG_OPEN && multiple) info.Flags |= OFN_ALLOWMULTISELECT;
 	if (!(kind == UI2_FILE_DIALOG_SAVE ? GetSaveFileNameW(&info) : GetOpenFileNameW(&info))) return 0;
 
 	wchar_t *next = selected + wcslen(selected) + 1;
 	if (*next == 0) {
-		ui2_win_file_dialog_append(output, output_capacity, 0, selected);
-		return output[0] != 0;
+		size_t used = 0;
+		return ui2_win_file_dialog_append(output, output_capacity, &used, selected) && output[0] != 0;
 	}
 	size_t used = 0;
-	const size_t folder_length = wcslen(selected);
+	if (!ui2_win_file_dialog_append(output, output_capacity, &used, selected)) return 0;
 	while (*next != 0) {
-		if (used > 0 && used + 1 < output_capacity) output[used++] = L'\n';
-		used = ui2_win_file_dialog_append(output, output_capacity, used, selected);
-		if (folder_length > 0 && selected[folder_length - 1] != L'\\' && used + 1 < output_capacity) output[used++] = L'\\';
-		used = ui2_win_file_dialog_append(output, output_capacity, used, next);
+		if (used + 1 >= output_capacity) return 0;
+		output[used++] = L'\n';
+		output[used] = 0;
+		if (!ui2_win_file_dialog_append(output, output_capacity, &used, next)) return 0;
 		next += wcslen(next) + 1;
 	}
 	return output[0] != 0;


### PR DESCRIPTION
Closes #7

## Summary
- add synchronous open, save, and folder picker APIs with extension filters
- implement NSOpenPanel/NSSavePanel, Win32 common dialogs, and Linux zenity/kdialog backends
- document the API and add a runnable example plus focused tests

## Verification
- `make check-linux V=/Users/alex/code/v8/v`
- `/Users/alex/code/v8/v -enable-globals -shared -os windows -check .`

The local V/macOS bridge dependency is older than this repository and prevents host-native AppKit/example test builds in unchanged files; Linux and Windows static checks cover the added backend sources.