### PR TITLE
Support single-quoted VML strings

### DIFF
--- a/ui/vml.v
+++ b/ui/vml.v
@@ -175,7 +175,7 @@ fn (mut l Lexer) skip_whitespace_and_comments() {
 
 fn (mut l Lexer) read_string() !Token {
 	line := l.line
-	l.advance() // skip opening quote
+	quote := l.advance()
 	mut val := []u8{}
 	for l.pos < l.src.len {
 		c := l.advance()
@@ -186,9 +186,10 @@ fn (mut l Lexer) read_string() !Token {
 				`t` { val << `\t` }
 				`\\` { val << `\\` }
 				`"` { val << `"` }
+				`'` { val << `'` }
 				else { val << next }
 			}
-		} else if c == `"` {
+		} else if c == quote {
 			return Token{.string_lit, val.bytestr(), line}
 		} else {
 			val << c
@@ -359,7 +360,7 @@ fn tokenize(source string) ![]Token {
 				l.advance()
 				tokens << Token{.or_or, '||', line}
 			}
-			`"` {
+			`"`, `'` {
 				tokens << l.read_string()!
 			}
 			else {

--- a/ui/vml_test.v
+++ b/ui/vml_test.v
@@ -195,6 +195,16 @@ fn test_parse_escaped_string() {
 	assert node.prop('text') == 'Hello "World"'
 }
 
+fn test_parse_single_quoted_strings() {
+	source := 'Label {
+		text: \'It\\\'s "fine"\'
+		tooltip: \'line one\\nline two\'
+	}'
+	node := parse_vml(source) or { panic(err) }
+	assert node.prop('text') == 'It\'s "fine"'
+	assert node.prop('tooltip') == 'line one\nline two'
+}
+
 fn test_parse_row() {
 	source := 'Row {
 		spacing: 10


### PR DESCRIPTION
## Summary
- accept single-quoted VML string literals alongside double-quoted literals
- support escaped apostrophes in single-quoted strings
- add parser coverage for single-quoted properties and escapes

## Tests
- `/tmp/ui2-v-build-20260910/v test ui/vml_test.v`
- `/tmp/ui2-v-build-20260910/v test ui/vml_model_test.v`

Closes #15