### PR TITLE
Fix compact users layout after resize

### DIFF
--- a/examples/users/users.vml
+++ b/examples/users/users.vml
@@ -13,350 +13,361 @@ Screen {
     property f64 age_width: root.table_width * 0.12
     property f64 country_width: root.table_width - root.first_width - root.last_width - root.age_width
 
-    Label {
-        text: "Add user"
-        x: 16
-        y: 8
-        width: root.form_width
-        height: 26
-        font_size: 18
-        bold: true
-    }
-
-    TextField {
-        id: first_name
-        bind.text: app.first_name
-        on_change: app.clear_error()
-        placeholder: "First name"
-        x: 16
-        y: 40
-        width: root.form_width
-        height: 32
-        background: app.is_error ? #FFEEEE : #FFFFFF
-        corner_radius: 6
-    }
-
-    TextField {
-        id: last_name
-        bind.text: app.last_name
-        on_change: app.clear_error()
-        placeholder: "Last name"
-        x: 16
-        y: 80
-        width: root.form_width
-        height: 32
-        background: app.is_error ? #FFEEEE : #FFFFFF
-        corner_radius: 6
-    }
-
-    TextField {
-        id: age
-        bind.text: app.age
-        on_change: app.clear_error()
-        placeholder: "Age"
-        keyboard: decimal
-        x: 16
-        y: 120
-        width: root.form_width
-        height: 32
-        background: app.is_error ? #FFEEEE : #FFFFFF
-        corner_radius: 6
-    }
-
-    TextField {
-        id: password
-        bind.text: app.password
-        placeholder: "Password"
-        secure: true
-        x: 16
-        y: 160
-        width: root.form_width
-        height: 32
-        background: #FFFFFF
-        corner_radius: 6
-    }
-
-    Checkbox {
-        id: online_registration
-        text: "Online registration"
-        bind.checked: app.online_registration
-        x: 16
-        y: 201
-        width: root.form_width
-        height: 30
-        font_size: 12
-    }
-
-    Checkbox {
-        id: subscribe
-        text: "Subscribe to the newsletter"
-        bind.checked: app.subscribe
-        x: 16
-        y: 239
-        width: root.form_width
-        height: 30
-        font_size: 12
-    }
-
-    Label {
-        text: "Country"
-        x: 16
-        y: 276
-        width: root.form_width
-        height: 18
-        color: #475569
-        font_size: 12
-    }
-
-    Dropdown {
-        id: country
-        bind.text: app.country
-        x: 16
-        y: 296
-        width: root.form_width
-        height: 32
-        background: #FFFFFF
-        font_size: 12
-        corner_radius: 6
-
-        Option { text: "United States" }
-        Option { text: "Canada" }
-        Option { text: "United Kingdom" }
-        Option { text: "Australia" }
-    }
-
-    Button {
-        id: add-user
-        text: "Add user"
-        enabled: app.users.len < app.max_users
-        on_tap: app.add_user()
-        native: true
-        x: 16
-        y: 337
-        width: 140
-        height: 32
-        background: #3478D4
-        color: #FFFFFF
-        corner_radius: 6
-        bold: true
-        align: center
-    }
-
-    Button {
-        id: help
-        text: "?"
-        on_tap: app.open_help()
-        native: true
-        tooltip: "About this example"
-        x: 178
-        y: 337
-        width: 48
-        height: 32
-        background: #E2E8F0
-        corner_radius: 16
-        bold: true
-        align: center
-    }
-
-    Rectangle {
-        x: 16
-        y: 371
-        width: 170
-        height: 16
-        background: #D8DEE8
-        corner_radius: 8
-
-        Rectangle {
-            x: 0
-            y: 0
-            width: 170 * app.users.len / app.max_users
-            height: 16
-            background: #3478D4
-            corner_radius: 8
-        }
-    }
-
-    Label {
-        text: "${app.users.len}/${app.max_users}"
-        x: 192
-        y: 368
-        width: root.form_width - 176
-        height: 22
-        font_size: 13
-    }
-
+    // A compact window stacks the table below the form. Keep that content
+    // reachable when the resized viewport is shorter than the stacked page.
     Scroll {
-        id: users_table
-        x: root.table_left
-        y: root.table_top
-        width: root.table_width
-        height: root.table_height
-        background: #FFFFFF
-        persistent: true
-
-        Rectangle {
-            x: 0
-            y: 0
-            width: root.table_width
-            height: 32
-            background: #334155
-
-            Label {
-                text: "First name"
-                x: 7
-                y: 0
-                width: root.first_width - 14
-                height: 32
-                color: #FFFFFF
-                font_size: 13
-                bold: true
-            }
-            Label {
-                text: "Last name"
-                x: root.first_width + 7
-                y: 0
-                width: root.last_width - 14
-                height: 32
-                color: #FFFFFF
-                font_size: 13
-                bold: true
-            }
-            Label {
-                text: "Age"
-                x: root.first_width + root.last_width + 7
-                y: 0
-                width: root.age_width - 14
-                height: 32
-                color: #FFFFFF
-                font_size: 13
-                bold: true
-            }
-            Label {
-                text: "Country"
-                x: root.first_width + root.last_width + root.age_width + 7
-                y: 0
-                width: root.country_width - 14
-                height: 32
-                color: #FFFFFF
-                font_size: 13
-                bold: true
-            }
-        }
-
-        Repeater {
-            model: app.users
-            key: item.id
-
-            Rectangle {
-                x: 0
-                y: 32 + index * 34
-                width: root.table_width
-                height: 32
-                background: index % 2 == 0 ? #FFFFFF : #F1F5F9
-
-                Label {
-                    text: item.first_name
-                    x: 7
-                    y: 0
-                    width: root.first_width - 14
-                    height: 32
-                    color: #1F2937
-                    font_size: 13
-                }
-                Label {
-                    text: item.last_name
-                    x: root.first_width + 7
-                    y: 0
-                    width: root.last_width - 14
-                    height: 32
-                    color: #1F2937
-                    font_size: 13
-                }
-                Label {
-                    text: "${item.age}"
-                    x: root.first_width + root.last_width + 7
-                    y: 0
-                    width: root.age_width - 14
-                    height: 32
-                    color: #1F2937
-                    font_size: 13
-                }
-                Label {
-                    text: item.country
-                    x: root.first_width + root.last_width + root.age_width + 7
-                    y: 0
-                    width: root.country_width - 14
-                    height: 32
-                    color: #1F2937
-                    font_size: 13
-                }
-            }
-        }
-    }
-
-    Image {
-        id: v_logo
-        hidden: root.compact
-        source: app.logo_path
-        x: root.table_left + root.table_width - 50
-        y: root.height - 66
-        width: 50
-        height: 50
-    }
-
-    Label {
-        hidden: !app.is_error
-        text: "First name, last name and age are required."
-        x: root.compact ? 16 : root.table_left
-        y: root.compact ? 390 : 302
-        width: root.compact ? root.form_width : root.table_width - 112
-        height: 24
-        color: #B42318
-        font_size: 13
-    }
-
-    Rectangle {
-        hidden: !app.show_help
-        x: root.width > 320 ? (root.width - 320) / 2 : 0
-        y: 118
-        width: 320
-        height: 145
-        background: #FFFFFF
-        corner_radius: 10
+        id: users_page
+        x: 0
+        y: 0
+        width: root.width
+        height: root.height
+        background: #F1F5F9
 
         Label {
-            text: "V UI Demo"
-            x: 20
-            y: 16
-            width: 280
-            height: 28
-            font_size: 19
+            text: "Add user"
+            x: 16
+            y: 8
+            width: root.form_width
+            height: 26
+            font_size: 18
             bold: true
-            align: center
         }
+
+        TextField {
+            id: first_name
+            bind.text: app.first_name
+            on_change: app.clear_error()
+            placeholder: "First name"
+            x: 16
+            y: 40
+            width: root.form_width
+            height: 32
+            background: app.is_error ? #FFEEEE : #FFFFFF
+            corner_radius: 6
+        }
+
+        TextField {
+            id: last_name
+            bind.text: app.last_name
+            on_change: app.clear_error()
+            placeholder: "Last name"
+            x: 16
+            y: 80
+            width: root.form_width
+            height: 32
+            background: app.is_error ? #FFEEEE : #FFFFFF
+            corner_radius: 6
+        }
+
+        TextField {
+            id: age
+            bind.text: app.age
+            on_change: app.clear_error()
+            placeholder: "Age"
+            keyboard: decimal
+            x: 16
+            y: 120
+            width: root.form_width
+            height: 32
+            background: app.is_error ? #FFEEEE : #FFFFFF
+            corner_radius: 6
+        }
+
+        TextField {
+            id: password
+            bind.text: app.password
+            placeholder: "Password"
+            secure: true
+            x: 16
+            y: 160
+            width: root.form_width
+            height: 32
+            background: #FFFFFF
+            corner_radius: 6
+        }
+
+        Checkbox {
+            id: online_registration
+            text: "Online registration"
+            bind.checked: app.online_registration
+            x: 16
+            y: 201
+            width: root.form_width
+            height: 30
+            font_size: 12
+        }
+
+        Checkbox {
+            id: subscribe
+            text: "Subscribe to the newsletter"
+            bind.checked: app.subscribe
+            x: 16
+            y: 239
+            width: root.form_width
+            height: 30
+            font_size: 12
+        }
+
         Label {
-            text: "Built with V, ui2 VML, and native controls."
-            x: 20
-            y: 52
-            width: 280
-            height: 24
-            font_size: 14
-            align: center
+            text: "Country"
+            x: 16
+            y: 276
+            width: root.form_width
+            height: 18
+            color: #475569
+            font_size: 12
         }
+
+        Dropdown {
+            id: country
+            bind.text: app.country
+            x: 16
+            y: 296
+            width: root.form_width
+            height: 32
+            background: #FFFFFF
+            font_size: 12
+            corner_radius: 6
+
+            Option { text: "United States" }
+            Option { text: "Canada" }
+            Option { text: "United Kingdom" }
+            Option { text: "Australia" }
+        }
+
         Button {
-            id: close-help
-            text: "Close"
-            on_tap: app.close_help()
+            id: add-user
+            text: "Add user"
+            enabled: app.users.len < app.max_users
+            on_tap: app.add_user()
             native: true
-            x: 100
-            y: 94
-            width: 120
-            height: 34
+            x: 16
+            y: 337
+            width: 140
+            height: 32
             background: #3478D4
             color: #FFFFFF
             corner_radius: 6
             bold: true
             align: center
+        }
+
+        Button {
+            id: help
+            text: "?"
+            on_tap: app.open_help()
+            native: true
+            tooltip: "About this example"
+            x: 178
+            y: 337
+            width: 48
+            height: 32
+            background: #E2E8F0
+            corner_radius: 16
+            bold: true
+            align: center
+        }
+
+        Rectangle {
+            x: 16
+            y: 371
+            width: 170
+            height: 16
+            background: #D8DEE8
+            corner_radius: 8
+
+            Rectangle {
+                x: 0
+                y: 0
+                width: 170 * app.users.len / app.max_users
+                height: 16
+                background: #3478D4
+                corner_radius: 8
+            }
+        }
+
+        Label {
+            text: "${app.users.len}/${app.max_users}"
+            x: 192
+            y: 368
+            width: root.form_width - 176
+            height: 22
+            font_size: 13
+        }
+
+        Scroll {
+            id: users_table
+            x: root.table_left
+            y: root.table_top
+            width: root.table_width
+            height: root.table_height
+            background: #FFFFFF
+            persistent: true
+
+            Rectangle {
+                x: 0
+                y: 0
+                width: root.table_width
+                height: 32
+                background: #334155
+
+                Label {
+                    text: "First name"
+                    x: 7
+                    y: 0
+                    width: root.first_width - 14
+                    height: 32
+                    color: #FFFFFF
+                    font_size: 13
+                    bold: true
+                }
+                Label {
+                    text: "Last name"
+                    x: root.first_width + 7
+                    y: 0
+                    width: root.last_width - 14
+                    height: 32
+                    color: #FFFFFF
+                    font_size: 13
+                    bold: true
+                }
+                Label {
+                    text: "Age"
+                    x: root.first_width + root.last_width + 7
+                    y: 0
+                    width: root.age_width - 14
+                    height: 32
+                    color: #FFFFFF
+                    font_size: 13
+                    bold: true
+                }
+                Label {
+                    text: "Country"
+                    x: root.first_width + root.last_width + root.age_width + 7
+                    y: 0
+                    width: root.country_width - 14
+                    height: 32
+                    color: #FFFFFF
+                    font_size: 13
+                    bold: true
+                }
+            }
+
+            Repeater {
+                model: app.users
+                key: item.id
+
+                Rectangle {
+                    x: 0
+                    y: 32 + index * 34
+                    width: root.table_width
+                    height: 32
+                    background: index % 2 == 0 ? #FFFFFF : #F1F5F9
+
+                    Label {
+                        text: item.first_name
+                        x: 7
+                        y: 0
+                        width: root.first_width - 14
+                        height: 32
+                        color: #1F2937
+                        font_size: 13
+                    }
+                    Label {
+                        text: item.last_name
+                        x: root.first_width + 7
+                        y: 0
+                        width: root.last_width - 14
+                        height: 32
+                        color: #1F2937
+                        font_size: 13
+                    }
+                    Label {
+                        text: "${item.age}"
+                        x: root.first_width + root.last_width + 7
+                        y: 0
+                        width: root.age_width - 14
+                        height: 32
+                        color: #1F2937
+                        font_size: 13
+                    }
+                    Label {
+                        text: item.country
+                        x: root.first_width + root.last_width + root.age_width + 7
+                        y: 0
+                        width: root.country_width - 14
+                        height: 32
+                        color: #1F2937
+                        font_size: 13
+                    }
+                }
+            }
+        }
+
+        Image {
+            id: v_logo
+            hidden: root.compact
+            source: app.logo_path
+            x: root.table_left + root.table_width - 50
+            y: root.height - 66
+            width: 50
+            height: 50
+        }
+
+        Label {
+            hidden: !app.is_error
+            text: "First name, last name and age are required."
+            x: root.compact ? 16 : root.table_left
+            y: root.compact ? 390 : 302
+            width: root.compact ? root.form_width : root.table_width - 112
+            height: 24
+            color: #B42318
+            font_size: 13
+        }
+
+        Rectangle {
+            hidden: !app.show_help
+            x: root.width > 320 ? (root.width - 320) / 2 : 0
+            y: 118
+            width: 320
+            height: 145
+            background: #FFFFFF
+            corner_radius: 10
+
+            Label {
+                text: "V UI Demo"
+                x: 20
+                y: 16
+                width: 280
+                height: 28
+                font_size: 19
+                bold: true
+                align: center
+            }
+            Label {
+                text: "Built with V, ui2 VML, and native controls."
+                x: 20
+                y: 52
+                width: 280
+                height: 24
+                font_size: 14
+                align: center
+            }
+            Button {
+                id: close-help
+                text: "Close"
+                on_tap: app.close_help()
+                native: true
+                x: 100
+                y: 94
+                width: 120
+                height: 34
+                background: #3478D4
+                color: #FFFFFF
+                corner_radius: 6
+                bold: true
+                align: center
+            }
         }
     }
 }

--- a/examples/users/users.vml
+++ b/examples/users/users.vml
@@ -325,49 +325,52 @@ Screen {
             font_size: 13
         }
 
-        Rectangle {
-            hidden: !app.show_help
-            x: root.width > 320 ? (root.width - 320) / 2 : 0
-            y: 118
-            width: 320
-            height: 145
-            background: #FFFFFF
-            corner_radius: 10
+    }
 
-            Label {
-                text: "V UI Demo"
-                x: 20
-                y: 16
-                width: 280
-                height: 28
-                font_size: 19
-                bold: true
-                align: center
-            }
-            Label {
-                text: "Built with V, ui2 VML, and native controls."
-                x: 20
-                y: 52
-                width: 280
-                height: 24
-                font_size: 14
-                align: center
-            }
-            Button {
-                id: close-help
-                text: "Close"
-                on_tap: app.close_help()
-                native: true
-                x: 100
-                y: 94
-                width: 120
-                height: 34
-                background: #3478D4
-                color: #FFFFFF
-                corner_radius: 6
-                bold: true
-                align: center
-            }
+    // Overlays stay in viewport coordinates while the compact page scrolls.
+    Rectangle {
+        id: help_dialog
+        hidden: !app.show_help
+        x: root.width > 320 ? (root.width - 320) / 2 : 0
+        y: 118
+        width: 320
+        height: 145
+        background: #FFFFFF
+        corner_radius: 10
+
+        Label {
+            text: "V UI Demo"
+            x: 20
+            y: 16
+            width: 280
+            height: 28
+            font_size: 19
+            bold: true
+            align: center
+        }
+        Label {
+            text: "Built with V, ui2 VML, and native controls."
+            x: 20
+            y: 52
+            width: 280
+            height: 24
+            font_size: 14
+            align: center
+        }
+        Button {
+            id: close-help
+            text: "Close"
+            on_tap: app.close_help()
+            native: true
+            x: 100
+            y: 94
+            width: 120
+            height: 34
+            background: #3478D4
+            color: #FFFFFF
+            corner_radius: 6
+            bold: true
+            align: center
         }
     }
 }

--- a/examples/users/users_test.v
+++ b/examples/users/users_test.v
@@ -81,6 +81,23 @@ fn test_users_screen_is_evaluated_from_model_vml() {
 	assert country.menu[1].title == 'Canada'
 }
 
+fn test_users_screen_keeps_stacked_content_reachable_after_compact_resize() {
+	data_path := users_test_data_path('compact-resize')
+	reset_test_users_data(data_path)
+	defer {
+		reset_test_users_data(data_path)
+	}
+	app := app_with_data_path(data_path)
+	resized := ui2.rect(0, 0, 500, 300)
+	root := ui2.element_from_vml_model(users_vml_source, app, resized) or { panic(err) }
+	page := find_element_by_id(root, 'users_page') or { panic('missing users page scroll') }
+	table := find_element_by_id(page, 'users_table') or { panic('missing compact users table') }
+	assert page.frame == resized
+	assert table.frame.x == 16
+	assert table.frame.y == 414
+	assert table.frame.y + table.frame.height > page.frame.height
+}
+
 fn test_app_add_user_is_only_business_logic() {
 	data_path := users_test_data_path('add')
 	reset_test_users_data(data_path)

--- a/examples/users/users_test.v
+++ b/examples/users/users_test.v
@@ -87,15 +87,20 @@ fn test_users_screen_keeps_stacked_content_reachable_after_compact_resize() {
 	defer {
 		reset_test_users_data(data_path)
 	}
-	app := app_with_data_path(data_path)
+	mut app := app_with_data_path(data_path)
+	app.show_help = true
 	resized := ui2.rect(0, 0, 500, 300)
 	root := ui2.element_from_vml_model(users_vml_source, app, resized) or { panic(err) }
 	page := find_element_by_id(root, 'users_page') or { panic('missing users page scroll') }
 	table := find_element_by_id(page, 'users_table') or { panic('missing compact users table') }
+	dialog := find_element_by_id(root, 'help_dialog') or { panic('missing help dialog') }
 	assert page.frame == resized
 	assert table.frame.x == 16
 	assert table.frame.y == 414
 	assert table.frame.y + table.frame.height > page.frame.height
+	assert dialog.frame == ui2.rect(90, 118, 320, 145)
+	assert !dialog.hidden
+	assert find_element_by_id(page, 'help_dialog') == none
 }
 
 fn test_app_add_user_is_only_business_logic() {

--- a/ui/ui_globals_immediate.c.v
+++ b/ui/ui_globals_immediate.c.v
@@ -22,6 +22,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 	// Using the clipped height for the range makes nested panes overscroll.
 	__global g_scroll_viewports = map[string]Rect{}
 	__global g_scroll_order = []string{}
+	__global g_scroll_parents = map[string]string{}
 	__global g_scrollbar_geometries = map[string]ScrollbarGeometry{}
 	__global g_text_area_layouts = map[string]TextAreaLayout{}
 }

--- a/ui/ui_immediate.c.v
+++ b/ui/ui_immediate.c.v
@@ -1633,6 +1633,7 @@ fn page_focused_text_area(direction int) {
 				for child in el.children {
 					child_screen_y := child.frame.y - scroll_y
 					if child_screen_y + child.frame.height < 0 || child_screen_y > el.frame.height {
+						retain_culled_scroll_state(child)
 						continue
 					}
 					render_element(ctx, child, x, y - scroll_y, child_clip, child_scroll_parent_id)

--- a/ui/ui_immediate.c.v
+++ b/ui/ui_immediate.c.v
@@ -56,6 +56,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		start_time         i64
 		moved              bool
 		scroll_id          string
+		scroll_chain       []string
 		long_press_fired   bool
 		scrollbar_drag     bool
 		scrollbar_grab_y   f64
@@ -696,6 +697,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			return
 		}
 		g_touch.scroll_id = scroll_hit_test(x, y)
+		g_touch.scroll_chain = scroll_ancestor_chain(g_touch.scroll_id)
 		if begin_scrollbar_drag(x, y) {
 			return
 		}
@@ -729,8 +731,8 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			drag_scrollbar(y)
 			return
 		}
-		if g_touch.scroll_id.len > 0 {
-			scroll_chain(g_touch.scroll_id, previous_y - y)
+		if g_touch.scroll_chain.len > 0 {
+			apply_scroll_chain(g_touch.scroll_chain, previous_y - y)
 		}
 		if target.action_id.len > 0 && target.draggable {
 			fire_event(pointer_event_id('drag', target.action_id, x, y))
@@ -747,7 +749,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		if id.len == 0 {
 			return
 		}
-		scroll_chain(id, -delta_y * 48)
+		apply_scroll_chain(scroll_ancestor_chain(id), -delta_y * 48)
 	}
 
 	fn set_scroll_offset(id string, requested f64, maximum f64) {

--- a/ui/ui_immediate.c.v
+++ b/ui/ui_immediate.c.v
@@ -56,7 +56,6 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		start_time         i64
 		moved              bool
 		scroll_id          string
-		scroll_start_off_y f64
 		long_press_fired   bool
 		scrollbar_drag     bool
 		scrollbar_grab_y   f64
@@ -579,7 +578,8 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		if has_root {
 			g_dropdown_popup.mounted = false
 			top := menu_bar_height()
-			render_element(ctx, root, 0, top, rect(0, top, f64(ctx.width), f64(ctx.height) - top))
+			render_element(ctx, root, 0, top, rect(0, top, f64(ctx.width), f64(ctx.height) - top),
+				'')
 			if g_open_dropdown.len > 0 {
 				if g_dropdown_popup.mounted {
 					draw_dropdown_popup(ctx)
@@ -696,7 +696,6 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			return
 		}
 		g_touch.scroll_id = scroll_hit_test(x, y)
-		g_touch.scroll_start_off_y = scroll_offset(g_touch.scroll_id)
 		if begin_scrollbar_drag(x, y) {
 			return
 		}
@@ -709,6 +708,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		if !g_touch.down {
 			return
 		}
+		previous_y := g_touch.current_y
 		dx := x - g_touch.start_x
 		dy := y - g_touch.start_y
 		if dx * dx + dy * dy > 100 {
@@ -730,9 +730,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			return
 		}
 		if g_touch.scroll_id.len > 0 {
-			delta := g_touch.start_y - y
-			new_offset := g_touch.scroll_start_off_y + delta
-			set_scroll_offset(g_touch.scroll_id, new_offset, scroll_maximum(g_touch.scroll_id))
+			scroll_chain(g_touch.scroll_id, previous_y - y)
 		}
 		if target.action_id.len > 0 && target.draggable {
 			fire_event(pointer_event_id('drag', target.action_id, x, y))
@@ -749,7 +747,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		if id.len == 0 {
 			return
 		}
-		set_scroll_offset(id, scroll_offset(id) - delta_y * 48, scroll_maximum(id))
+		scroll_chain(id, -delta_y * 48)
 	}
 
 	fn set_scroll_offset(id string, requested f64, maximum f64) {
@@ -1567,7 +1565,7 @@ fn page_focused_text_area(direction int) {
 
 	// ── Rendering ──────────────────────────────────────────────────────
 
-	fn render_element(ctx &gg.Context, el Element, off_x f64, off_y f64, clip Rect) {
+	fn render_element(ctx &gg.Context, el Element, off_x f64, off_y f64, clip Rect, scroll_parent_id string) {
 		if el.hidden {
 			return
 		}
@@ -1581,7 +1579,7 @@ fn page_focused_text_area(direction int) {
 				}
 				draw_box_borders(ctx, off_x, off_y, w - off_x, h - off_y, el.box)
 				for child in el.children {
-					render_element(ctx, child, off_x, off_y, clip)
+					render_element(ctx, child, off_x, off_y, clip, scroll_parent_id)
 				}
 			}
 			.view {
@@ -1607,7 +1605,7 @@ fn page_focused_text_area(direction int) {
 					}, clip)
 				}
 				for child in el.children {
-					render_element(ctx, child, x, y, clip)
+					render_element(ctx, child, x, y, clip, scroll_parent_id)
 				}
 			}
 			.scroll {
@@ -1626,15 +1624,16 @@ fn page_focused_text_area(direction int) {
 				if content_h > 0 {
 					content_h += 16
 				}
-				scroll_y := register_scroll_view(el.id, frame, clip, content_h, el.enabled,
+				scroll_y := register_scroll_view_in_parent(el.id, scroll_parent_id, frame, clip, content_h, el.enabled,
 					true, el.persistent_scrollbars)
+				child_scroll_parent_id := if el.id.len > 0 { el.id } else { scroll_parent_id }
 				child_clip := intersect_rect(frame, clip)
 				for child in el.children {
 					child_screen_y := child.frame.y - scroll_y
 					if child_screen_y + child.frame.height < 0 || child_screen_y > el.frame.height {
 						continue
 					}
-					render_element(ctx, child, x, y - scroll_y, child_clip)
+					render_element(ctx, child, x, y - scroll_y, child_clip, child_scroll_parent_id)
 				}
 				if child_clip.width > 0 && child_clip.height > 0 {
 					apply_clip(ctx, child_clip)
@@ -1929,7 +1928,7 @@ fn page_focused_text_area(direction int) {
 				current_text := g_text_values[el.id] or { el.text }
 				draw_control_surface(ctx, x, y, el.frame.width, el.frame.height, el.box,
 					g_focused_field == el.id, el.enabled)
-				draw_text_area_content(ctx, el, current_text, x, y, clip)
+				draw_text_area_content(ctx, el, current_text, x, y, clip, scroll_parent_id)
 				if el.enabled && !el.readonly {
 					add_hit_target(HitTarget{
 						id: el.id

--- a/ui/ui_scroll_immediate.c.v
+++ b/ui/ui_scroll_immediate.c.v
@@ -63,6 +63,28 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		return offset
 	}
 
+	// Rendering skips subtrees outside a scroll viewport, but those elements are
+	// still mounted. Keep their scroll-backed state active so unmount cleanup
+	// does not discard positions that must be restored when they re-enter view.
+	fn retain_culled_scroll_state(el Element) {
+		if el.hidden {
+			return
+		}
+		if el.kind == .scroll {
+			if el.id.len > 0 {
+				g_active_scrolls[el.id] = true
+			}
+		} else if el.kind == .text_area {
+			id := text_area_scroll_id(el)
+			if id.len > 0 {
+				g_active_scrolls[id] = true
+			}
+		}
+		for child in el.children {
+			retain_culled_scroll_state(child)
+		}
+	}
+
 	fn scroll_rect_contains(r Rect, x f64, y f64) bool {
 		return r.width > 0 && r.height > 0 && x >= r.x && x < r.x + r.width
 			&& y >= r.y && y < r.y + r.height

--- a/ui/ui_scroll_immediate.c.v
+++ b/ui/ui_scroll_immediate.c.v
@@ -19,6 +19,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		g_scroll_areas = map[string]Rect{}
 		g_scroll_viewports = map[string]Rect{}
 		g_scroll_order = []string{}
+		g_scroll_parents = map[string]string{}
 		g_scrollbar_geometries = map[string]ScrollbarGeometry{}
 	}
 
@@ -32,12 +33,20 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 	}
 
 	fn register_scroll_view(id string, frame Rect, clip Rect, content_height f64, enabled bool, show_scrollbar bool, persistent bool) f64 {
+		return register_scroll_view_in_parent(id, '', frame, clip, content_height, enabled,
+			show_scrollbar, persistent)
+	}
+
+	fn register_scroll_view_in_parent(id string, parent_id string, frame Rect, clip Rect, content_height f64, enabled bool, show_scrollbar bool, persistent bool) f64 {
 		if id.len == 0 {
 			return 0.0
 		}
 		g_active_scrolls[id] = true
 		g_scroll_viewports[id] = frame
 		g_scroll_content_h[id] = content_height
+		if parent_id.len > 0 {
+			g_scroll_parents[id] = parent_id
+		}
 		// Preserve the position across rebuilds and resizes, only clamping when
 		// the content or viewport changes the available range.
 		set_scroll_offset(id, scroll_offset(id), scroll_maximum(id))
@@ -71,6 +80,24 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			}
 		}
 		return ''
+	}
+
+	// Apply a scroll delta to the innermost pane first, then pass any distance
+	// left at its boundary to each scrollable ancestor.
+	fn scroll_chain(id string, delta f64) {
+		mut current_id := id
+		mut remaining := delta
+		for _ in 0 .. g_scroll_viewports.len {
+			if current_id.len == 0 || math.abs(remaining) < 0.000001 {
+				return
+			}
+			if current_id in g_scroll_areas {
+				before := scroll_offset(current_id)
+				set_scroll_offset(current_id, before + remaining, scroll_maximum(current_id))
+				remaining -= scroll_offset(current_id) - before
+			}
+			current_id = g_scroll_parents[current_id] or { '' }
+		}
 	}
 
 	fn scrollbar_geometry(frame Rect, content_height f64, offset f64, persistent bool) ScrollbarGeometry {
@@ -343,7 +370,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		return first, last
 	}
 
-	fn draw_text_area_content(ctx &gg.Context, el Element, value string, x f64, y f64, clip Rect) {
+	fn draw_text_area_content(ctx &gg.Context, el Element, value string, x f64, y f64, clip Rect, scroll_parent_id string) {
 		frame := rect(x, y, el.frame.width, el.frame.height)
 		content := text_area_content_rect(frame, el.padding_left, !el.disable_scroll)
 		style := el.text_style
@@ -371,7 +398,7 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		// Read-only means not editable, not unscrollable. disable_scroll only
 		// hides the scroller, matching Element's documented/native behavior.
 		scroll_id := text_area_scroll_id(el)
-		offset := register_scroll_view(scroll_id, frame, clip, content_height, el.enabled,
+		offset := register_scroll_view_in_parent(scroll_id, scroll_parent_id, frame, clip, content_height, el.enabled,
 			!el.disable_scroll, el.persistent_scrollbars)
 		text_clip := intersect_rect(content, clip)
 		if text_clip.width > 0 && text_clip.height > 0 {

--- a/ui/ui_scroll_immediate.c.v
+++ b/ui/ui_scroll_immediate.c.v
@@ -64,7 +64,9 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		for index := g_scroll_order.len - 1; index >= 0; index-- {
 			id := g_scroll_order[index]
 			area := g_scroll_areas[id] or { continue }
-			if scroll_rect_contains(area, x, y) {
+			// A fitted child has nowhere to scroll. Let its scrollable parent
+			// receive the wheel or drag instead of trapping the gesture here.
+			if scroll_maximum(id) > 0 && scroll_rect_contains(area, x, y) {
 				return id
 			}
 		}

--- a/ui/ui_scroll_immediate.c.v
+++ b/ui/ui_scroll_immediate.c.v
@@ -82,21 +82,34 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 		return ''
 	}
 
-	// Apply a scroll delta to the innermost pane first, then pass any distance
-	// left at its boundary to each scrollable ancestor.
-	fn scroll_chain(id string, delta f64) {
+	fn scroll_ancestor_chain(id string) []string {
+		mut chain := []string{}
 		mut current_id := id
-		mut remaining := delta
 		for _ in 0 .. g_scroll_viewports.len {
-			if current_id.len == 0 || math.abs(remaining) < 0.000001 {
+			if current_id.len == 0 {
+				break
+			}
+			chain << current_id
+			current_id = g_scroll_parents[current_id] or { '' }
+		}
+		return chain
+	}
+
+	// Apply a scroll delta to the innermost available pane first, then pass any
+	// distance left at its boundary to each available ancestor. Touch input
+	// captures this chain on pointer-down so frame culling cannot sever it.
+	fn apply_scroll_chain(chain []string, delta f64) {
+		mut remaining := delta
+		for id in chain {
+			if math.abs(remaining) < 0.000001 {
 				return
 			}
-			if current_id in g_scroll_areas {
-				before := scroll_offset(current_id)
-				set_scroll_offset(current_id, before + remaining, scroll_maximum(current_id))
-				remaining -= scroll_offset(current_id) - before
+			if id !in g_scroll_areas {
+				continue
 			}
-			current_id = g_scroll_parents[current_id] or { '' }
+			before := scroll_offset(id)
+			set_scroll_offset(id, before + remaining, scroll_maximum(id))
+			remaining -= scroll_offset(id) - before
 		}
 	}
 

--- a/ui/ui_scroll_immediate_test.v
+++ b/ui/ui_scroll_immediate_test.v
@@ -184,6 +184,19 @@ fn test_text_area_wraps_words_and_preserves_explicit_blank_lines() {
 		assert scroll_offset('inner') == 48
 	}
 
+	fn test_scroll_hit_testing_falls_through_a_fitted_child_to_its_parent() {
+		reset_scroll_test_state()
+		clip := rect(0, 0, 300, 300)
+		register_scroll_view('outer', clip, clip, 1000, true, true, false)
+		register_scroll_view('inner', rect(20, 20, 100, 100), clip, 100, true, true,
+			false)
+		assert scroll_maximum('inner') == 0
+		assert scroll_hit_test(50, 50) == 'outer'
+		handle_mouse_scroll(50, 50, -1)
+		assert scroll_offset('inner') == 0
+		assert scroll_offset('outer') == 48
+	}
+
 	fn test_keyed_anonymous_text_areas_get_independent_nested_scroll_state() {
 		reset_scroll_test_state()
 		first := Element{kind: .text_area, key: '0'}
@@ -214,6 +227,7 @@ fn test_text_area_wraps_words_and_preserves_explicit_blank_lines() {
 		reset_scroll_test_state()
 		frame := rect(0, 0, 100, 100)
 		register_scroll_view('short', frame, frame, 50, true, true, false)
+		assert scroll_hit_test(50, 50) == ''
 		on_scroll(scroll_test_changed)
 		handle_mouse_scroll(50, 50, -1)
 		assert scroll_offset('short') == 0

--- a/ui/ui_scroll_immediate_test.v
+++ b/ui/ui_scroll_immediate_test.v
@@ -246,6 +246,35 @@ fn test_text_area_wraps_words_and_preserves_explicit_blank_lines() {
 		assert scroll_test_events == ['inner', 'outer', 'outer', 'inner']
 	}
 
+	fn test_touch_drag_keeps_its_parent_chain_when_the_child_is_culled() {
+		reset_scroll_test_state()
+		nested_scroll_test_panes()
+		set_scroll_offset('inner', 80, scroll_maximum('inner'))
+
+		handle_touch_down(50, 80)
+		assert g_touch.scroll_chain == ['inner', 'outer']
+		handle_touch_move(50, 30)
+		assert scroll_offset('inner') == 100
+		assert scroll_offset('outer') == 30
+
+		// Simulate the next frame after the parent has moved the child outside
+		// its viewport. Only the parent is registered and the child is pruned.
+		g_active_scrolls = map[string]bool{}
+		reset_scroll_frame()
+		clip := rect(0, 0, 300, 300)
+		register_scroll_view('outer', clip, clip, 1200, true, true, false)
+		prune_unmounted_state()
+		assert 'inner' !in g_scroll_viewports
+		assert 'inner' !in g_scroll_offsets
+		assert g_scroll_parents.len == 0
+
+		handle_touch_move(50, 0)
+		assert scroll_offset('outer') == 60
+		handle_touch_move(50, 40)
+		assert scroll_offset('outer') == 20
+		handle_touch_up(50, 40)
+	}
+
 	fn test_keyed_anonymous_text_areas_get_independent_nested_scroll_state() {
 		reset_scroll_test_state()
 		first := Element{kind: .text_area, key: '0'}

--- a/ui/ui_scroll_immediate_test.v
+++ b/ui/ui_scroll_immediate_test.v
@@ -197,6 +197,55 @@ fn test_text_area_wraps_words_and_preserves_explicit_blank_lines() {
 		assert scroll_offset('outer') == 48
 	}
 
+	fn nested_scroll_test_panes() {
+		clip := rect(0, 0, 300, 300)
+		register_scroll_view('outer', clip, clip, 1200, true, true, false)
+		register_scroll_view_in_parent('inner', 'outer', rect(20, 20, 100, 100), clip,
+			200, true, true, false)
+	}
+
+	fn test_mouse_wheel_chains_remaining_delta_to_a_parent_at_child_boundary() {
+		reset_scroll_test_state()
+		nested_scroll_test_panes()
+		set_scroll_offset('inner', 80, scroll_maximum('inner'))
+		on_scroll(scroll_test_changed)
+
+		handle_mouse_scroll(50, 50, -1)
+		assert scroll_offset('inner') == 100
+		assert scroll_offset('outer') == 28
+		handle_mouse_scroll(50, 50, -1)
+		assert scroll_offset('inner') == 100
+		assert scroll_offset('outer') == 76
+		assert scroll_test_events == ['inner', 'outer', 'outer']
+
+		set_scroll_offset('inner', 0, scroll_maximum('inner'))
+		scroll_test_events = []string{}
+		handle_mouse_scroll(50, 50, 1)
+		assert scroll_offset('inner') == 0
+		assert scroll_offset('outer') == 28
+		assert scroll_test_events == ['outer']
+	}
+
+	fn test_touch_drag_chains_remaining_delta_and_reverses_into_the_child() {
+		reset_scroll_test_state()
+		nested_scroll_test_panes()
+		set_scroll_offset('inner', 80, scroll_maximum('inner'))
+		on_scroll(scroll_test_changed)
+
+		handle_touch_down(50, 80)
+		handle_touch_move(50, 30)
+		assert scroll_offset('inner') == 100
+		assert scroll_offset('outer') == 30
+		handle_touch_move(50, 0)
+		assert scroll_offset('inner') == 100
+		assert scroll_offset('outer') == 60
+		handle_touch_move(50, 40)
+		assert scroll_offset('inner') == 60
+		assert scroll_offset('outer') == 60
+		handle_touch_up(50, 40)
+		assert scroll_test_events == ['inner', 'outer', 'outer', 'inner']
+	}
+
 	fn test_keyed_anonymous_text_areas_get_independent_nested_scroll_state() {
 		reset_scroll_test_state()
 		first := Element{kind: .text_area, key: '0'}

--- a/ui/ui_scroll_immediate_test.v
+++ b/ui/ui_scroll_immediate_test.v
@@ -258,20 +258,36 @@ fn test_text_area_wraps_words_and_preserves_explicit_blank_lines() {
 		assert scroll_offset('outer') == 30
 
 		// Simulate the next frame after the parent has moved the child outside
-		// its viewport. Only the parent is registered and the child is pruned.
+		// its viewport. Only the parent is registered, but the renderer retains
+		// scroll state from the child's still-mounted element subtree.
 		g_active_scrolls = map[string]bool{}
 		reset_scroll_frame()
 		clip := rect(0, 0, 300, 300)
 		register_scroll_view('outer', clip, clip, 1200, true, true, false)
+		retain_culled_scroll_state(Element{
+			kind: .view
+			children: [Element{
+				kind: .scroll
+				id: 'inner'
+			}]
+		})
 		prune_unmounted_state()
 		assert 'inner' !in g_scroll_viewports
-		assert 'inner' !in g_scroll_offsets
+		assert scroll_offset('inner') == 100
+		assert g_scroll_content_h['inner'] == 200
 		assert g_scroll_parents.len == 0
 
 		handle_touch_move(50, 0)
 		assert scroll_offset('outer') == 60
 		handle_touch_move(50, 40)
 		assert scroll_offset('outer') == 20
+
+		// Re-registering the child after it re-enters the viewport restores its
+		// previous position instead of jumping back to the top.
+		reset_scroll_frame()
+		register_scroll_view('outer', clip, clip, 1200, true, true, false)
+		assert register_scroll_view_in_parent('inner', 'outer', rect(20, 20, 100,
+			100), clip, 200, true, true, false) == 100
 		handle_touch_up(50, 40)
 	}
 


### PR DESCRIPTION
## Summary

- make the compact users example vertically scrollable so the stacked table remains reachable in short windows
- let scroll gestures fall through fitted nested panes to a scrollable parent
- add regressions for compact resizing and nested scroll hit testing

## Verification

- users example tests
- immediate scroll renderer tests with custom rendering
- Linux backend cross-checks
- custom-renderer shared check
- recorded 780x420 and 500x300 custom-renderer frames