### PR TITLE
Keep users table beside form at minimum width

### DIFF
--- a/appkit/ui_macos_darwin.v
+++ b/appkit/ui_macos_darwin.v
@@ -37,6 +37,8 @@ struct RunConfig {
 	title  string = 'App'
 	width  int = 400
 	height int = 800
+	min_width  int
+	min_height int
 }
 
 struct RefreshDebug {
@@ -160,6 +162,10 @@ pub fn run(build_fn BuildFn, event_fn EventFn) {
 }
 
 pub fn run_window(title string, width int, height int, build_fn BuildFn, event_fn EventFn) {
+	run_window_with_min_size(title, width, height, 0, 0, build_fn, event_fn)
+}
+
+fn run_window_with_min_size(title string, width int, height int, min_width int, min_height int, build_fn BuildFn, event_fn EventFn) {
 	mut st := state()
 	st.build_screen = build_fn
 	st.event_handler = event_fn
@@ -168,6 +174,8 @@ pub fn run_window(title string, width int, height int, build_fn BuildFn, event_f
 		title: title
 		width: width
 		height: height
+		min_width: min_width
+		min_height: min_height
 	}
 	publish_menu_context(event_fn, title, unsafe { nil })
 	ensure_runtime_classes()
@@ -1649,6 +1657,10 @@ fn native_set_content_view(window NativeView, view NativeView) {
 	macos.msg_void1(window, 'setContentView:', view)
 }
 
+fn native_set_content_min_size(window NativeView, width f64, height f64) {
+	macos.msg_void_point(window, 'setContentMinSize:', macos.point(width, height))
+}
+
 fn native_bounds(view NativeView) NativeRect {
 	b := macos.msg_rect(view, 'bounds')
 	return native_rect(b.x, b.y, b.width, b.height)
@@ -2248,6 +2260,8 @@ fn ui2_app_did_finish_launching(_self voidptr, _cmd voidptr, _notification voidp
 	install_declared_menus()
 	frame := native_rect(120, 120, f64(st.run_config.width), f64(st.run_config.height))
 	st.window = native_new_window(frame, st.run_config.title)
+	native_set_content_min_size(st.window, f64(st.run_config.min_width),
+		f64(st.run_config.min_height))
 	// The app delegate doubles as window delegate for windowDidResize:
 	macos.msg_void1(st.window, 'setDelegate:', st.app_delegate)
 	root_frame := native_rect(0, 0, f64(st.run_config.width), f64(st.run_config.height))

--- a/examples/users/main.v
+++ b/examples/users/main.v
@@ -6,6 +6,7 @@ import ui2
 
 const window_width = 780
 const window_height = 420
+const window_min_width = 700
 const maximum_users = 10
 const users_data_directory = 'ui2-users-example'
 const users_data_filename = 'users.json'
@@ -187,6 +188,7 @@ fn main() {
 		title: 'V UI Demo'
 		width: window_width
 		height: window_height
+		min_width: window_min_width
 	) or {
 		panic(err)
 	}

--- a/examples/users/users.vml
+++ b/examples/users/users.vml
@@ -2,19 +2,18 @@ Screen {
     id: root
     background: #F1F5F9
 
-    property bool compact: root.width < 700
-    property f64 form_width: root.compact ? root.width - 32 : 210
-    property f64 table_left: root.compact ? 16 : 244
-    property f64 table_top: root.compact ? 414 : 16
-    property f64 table_width: root.compact ? root.form_width : root.width - 260
-    property f64 table_height: root.compact && root.height - root.table_top - 16 > 220 ? root.height - root.table_top - 16 : 270
+    property f64 form_width: 210
+    property f64 table_left: 244
+    property f64 table_top: 16
+    property f64 table_width: root.width - 260
+    property f64 table_height: 270
     property f64 first_width: root.table_width * 0.23
     property f64 last_width: root.table_width * 0.23
     property f64 age_width: root.table_width * 0.12
     property f64 country_width: root.table_width - root.first_width - root.last_width - root.age_width
 
-    // A compact window stacks the table below the form. Keep that content
-    // reachable when the resized viewport is shorter than the stacked page.
+    // Keep the form and table on one row. The window runner enforces the
+    // minimum width, while this page scroll keeps short windows usable.
     Scroll {
         id: users_page
         x: 0
@@ -306,7 +305,6 @@ Screen {
 
         Image {
             id: v_logo
-            hidden: root.compact
             source: app.logo_path
             x: root.table_left + root.table_width - 50
             y: root.height - 66
@@ -317,9 +315,9 @@ Screen {
         Label {
             hidden: !app.is_error
             text: "First name, last name and age are required."
-            x: root.compact ? 16 : root.table_left
-            y: root.compact ? 390 : 302
-            width: root.compact ? root.form_width : root.table_width - 112
+            x: root.table_left
+            y: 302
+            width: root.table_width - 112
             height: 24
             color: #B42318
             font_size: 13

--- a/examples/users/users_test.v
+++ b/examples/users/users_test.v
@@ -81,24 +81,24 @@ fn test_users_screen_is_evaluated_from_model_vml() {
 	assert country.menu[1].title == 'Canada'
 }
 
-fn test_users_screen_keeps_stacked_content_reachable_after_compact_resize() {
-	data_path := users_test_data_path('compact-resize')
+fn test_users_screen_keeps_table_beside_form_at_minimum_width() {
+	data_path := users_test_data_path('minimum-width')
 	reset_test_users_data(data_path)
 	defer {
 		reset_test_users_data(data_path)
 	}
 	mut app := app_with_data_path(data_path)
 	app.show_help = true
-	resized := ui2.rect(0, 0, 500, 300)
+	resized := ui2.rect(0, 0, window_min_width, 300)
 	root := ui2.element_from_vml_model(users_vml_source, app, resized) or { panic(err) }
 	page := find_element_by_id(root, 'users_page') or { panic('missing users page scroll') }
-	table := find_element_by_id(page, 'users_table') or { panic('missing compact users table') }
+	table := find_element_by_id(page, 'users_table') or { panic('missing users table') }
 	dialog := find_element_by_id(root, 'help_dialog') or { panic('missing help dialog') }
 	assert page.frame == resized
-	assert table.frame.x == 16
-	assert table.frame.y == 414
-	assert table.frame.y + table.frame.height > page.frame.height
-	assert dialog.frame == ui2.rect(90, 118, 320, 145)
+	assert table.frame.x == 244
+	assert table.frame.y == 16
+	assert table.frame.width == window_min_width - 260
+	assert dialog.frame == ui2.rect(190, 118, 320, 145)
 	assert !dialog.hidden
 	assert find_element_by_id(page, 'help_dialog') == none
 }

--- a/ui/ui_immediate.c.v
+++ b/ui/ui_immediate.c.v
@@ -230,6 +230,10 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 	}
 
 	pub fn run_window(title string, width int, height int, build_fn BuildFn, event_fn EventFn) {
+		run_window_with_min_size(title, width, height, 0, 0, build_fn, event_fn)
+	}
+
+	fn run_window_with_min_size(title string, width int, height int, min_width int, min_height int, build_fn BuildFn, event_fn EventFn) {
 		g_build_screen = build_fn
 		g_event_handler = event_fn
 		configure_animation_driver(request_refresh, false)
@@ -247,6 +251,8 @@ $if (android || linux || ((macos || windows) && ui2_custom_rendering ?)) && !ui2
 			custom_bold_font_path: font_bold
 			width: width
 			height: height
+			min_width: min_width
+			min_height: min_height
 			sample_count: 4
 			create_window: true
 			window_title: title

--- a/ui/vml_compiled.v
+++ b/ui/vml_compiled.v
@@ -187,6 +187,8 @@ pub:
 	title  string = 'App'
 	width  int = 400
 	height int = 800
+	min_width  int
+	min_height int
 }
 
 @[heap]
@@ -242,7 +244,8 @@ pub fn run_compiled_vml[T](config CompiledVmlRunConfig[T]) ! {
 	mut runtime := compiled_vml_runtime()
 	runtime.controller = voidptr(controller)
 	$if macos || windows || linux {
-		run_window(config.title, config.width, config.height, compiled_vml_controller_build[T], compiled_vml_controller_handle[T])
+		run_window_with_min_size(config.title, config.width, config.height, config.min_width,
+			config.min_height, compiled_vml_controller_build[T], compiled_vml_controller_handle[T])
 	} $else {
 		run(compiled_vml_controller_build[T], compiled_vml_controller_handle[T])
 	}

--- a/ui/vml_model.v
+++ b/ui/vml_model.v
@@ -1526,6 +1526,8 @@ pub:
 	title  string = 'App'
 	width  int    = 400
 	height int    = 800
+	min_width  int
+	min_height int
 }
 
 @[heap]
@@ -1647,8 +1649,8 @@ pub fn run_vml[T](config VmlRunConfig[T]) ! {
 	mut runtime := vml_runtime()
 	runtime.controller = voidptr(controller)
 	$if macos || windows || linux {
-		run_window(config.title, config.width, config.height, vml_controller_build[T],
-			vml_controller_handle[T])
+		run_window_with_min_size(config.title, config.width, config.height, config.min_width,
+			config.min_height, vml_controller_build[T], vml_controller_handle[T])
 	} $else {
 		run(vml_controller_build[T], vml_controller_handle[T])
 	}

--- a/windows/native_helpers_windows.h
+++ b/windows/native_helpers_windows.h
@@ -339,6 +339,18 @@ static inline void *ui2_win_create_main_window(const wchar_t *title, int width, 
 	return hwnd;
 }
 
+static inline void ui2_win_apply_min_size(void *hwnd_ptr, intptr_t lparam,
+		int width, int height) {
+	if (lparam == 0 || (width <= 0 && height <= 0)) return;
+	HWND hwnd = (HWND)hwnd_ptr;
+	RECT frame = {0, 0, width > 0 ? width : 0, height > 0 ? height : 0};
+	AdjustWindowRectEx(&frame, (DWORD)GetWindowLongPtrW(hwnd, GWL_STYLE),
+		GetMenu(hwnd) != NULL, (DWORD)GetWindowLongPtrW(hwnd, GWL_EXSTYLE));
+	MINMAXINFO *info = (MINMAXINFO *)lparam;
+	if (width > 0) info->ptMinTrackSize.x = frame.right - frame.left;
+	if (height > 0) info->ptMinTrackSize.y = frame.bottom - frame.top;
+}
+
 static inline void ui2_win_set_window_title(void *hwnd, const wchar_t *title) {
 	if (hwnd != NULL) SetWindowTextW((HWND)hwnd, title == NULL ? L"" : title);
 }

--- a/windows/ui_windows.v
+++ b/windows/ui_windows.v
@@ -20,6 +20,8 @@ fn C.ui2_win_visual_styles_enabled() int
 
 fn C.ui2_win_create_main_window(title &u16, width int, height int) voidptr
 
+fn C.ui2_win_apply_min_size(hwnd voidptr, lparam isize, width int, height int)
+
 fn C.ui2_win_set_window_title(hwnd voidptr, title &u16)
 
 fn C.ui2_win_create_widget(kind int, parent voidptr, x int, y int, width int, height int, text &u16, alignment int, secure int, readonly int, disable_scroll int, vertical int) voidptr
@@ -188,6 +190,7 @@ const win_wm_mouse_wheel = u32(0x020a)
 const win_wm_dropfiles = u32(0x0233)
 const win_wm_refresh = u32(0x8000 + 77)
 const win_wm_paint_background = u32(0x8000 + 79)
+const win_wm_getminmaxinfo = u32(0x0024)
 
 const win_bn_clicked = 0
 const win_cbn_selchange = 1
@@ -197,6 +200,8 @@ struct WindowsRunConfig {
 	title  string = 'App'
 	width  int = 400
 	height int = 800
+	min_width  int
+	min_height int
 }
 
 struct WindowsPointerBinding {
@@ -363,6 +368,10 @@ pub fn run(build_fn BuildFn, event_fn EventFn) {
 }
 
 pub fn run_window(title string, width int, height int, build_fn BuildFn, event_fn EventFn) {
+	run_window_with_min_size(title, width, height, 0, 0, build_fn, event_fn)
+}
+
+fn run_window_with_min_size(title string, width int, height int, min_width int, min_height int, build_fn BuildFn, event_fn EventFn) {
 	mut st := windows_state()
 	st.build_screen = build_fn
 	st.event_handler = event_fn
@@ -371,6 +380,8 @@ pub fn run_window(title string, width int, height int, build_fn BuildFn, event_f
 		title: title
 		width: width
 		height: height
+		min_width: min_width
+		min_height: min_height
 	}
 	if C.ui2_win_register_classes() == 0 {
 		eprintln('ui2: failed to register Win32 window classes')
@@ -1332,6 +1343,11 @@ fn windows_handle_drop(drop voidptr) {
 fn ui2_windows_window_proc(hwnd voidptr, message u32, wparam usize, lparam isize) isize {
 	mut st := windows_state()
 	match message {
+		win_wm_getminmaxinfo {
+			C.ui2_win_apply_min_size(hwnd, lparam, st.run_config.min_width,
+				st.run_config.min_height)
+			return 0
+		}
 		win_wm_command {
 			child := voidptr(usize(lparam))
 			if child == unsafe { nil } {


### PR DESCRIPTION
## Summary
- keep the users form and table side-by-side instead of switching to a stacked layout
- add `min_width` and `min_height` to runtime and compiled VML window configs
- enforce minimum content dimensions in gg/Linux, AppKit, and Win32 backends
- cover the users layout at its 700px minimum width

## Verification
- `v -path '/Users/alex/code|@vlib|@vmodules' examples/users/users_test.v`\n- native and custom macOS builds of `examples/users/main.v`\n- Linux and Windows cross-target checks of `examples/users/main.v`\n- `make check-macos`\n- `make check-linux`\n- full shared-module checks for native Windows and custom macOS/Windows\n- `v -d ui2_custom_rendering test ui` (scroll suite passed; unrelated existing failures remain in `text_editor_test.v` and `ui_custom_test.v`)\n\nFollow-up to #28.